### PR TITLE
style(header): 헤더 타이틀 및 로그인 텍스트 크기 조정

### DIFF
--- a/LiveStudy-front/src/components/common/Header.tsx
+++ b/LiveStudy-front/src/components/common/Header.tsx
@@ -2,8 +2,8 @@ const Header = () => {
   return (
     <header className="w-full">
       <div className="max-w-[1280px] mx-auto px-4 py-4 flex justify-between items-center">
-        <h1 className="text-headline4_B text-primary-600">LiveStudy</h1>
-        <div className="text-caption2_SB text-gray-400">로그인</div>
+        <h1 className="text-headline3_B text-primary-600">LiveStudy</h1>
+        <div className="text-caption1_M text-gray-400">로그인</div>
       </div>
     </header>
   );

--- a/tall react-icons
+++ b/tall react-icons
@@ -1,0 +1,57 @@
+[33mcommit 6fe39d2941c76efc7cc0312d789c0918cb1169dd[m[33m ([m[1;31morigin/feature/jiho-header-component[m[33m, [m[1;32mfeature/jiho-header-component[m[33m)[m
+Merge: 24a08a8 087dada
+Author: jinwon <110159742+JinwonShen@users.noreply.github.com>
+Date:   Tue Jul 15 14:48:43 2025 +0900
+
+    Merge pull request #8 from LiveStudy-group/feature/jiho-header-component
+    
+    Feature/jiho header component
+
+[33mcommit 24a08a8aa10ead2ddf626e114783ca9d7aa10255[m
+Merge: 3e4c589 ab302e6
+Author: jinwon <110159742+JinwonShen@users.noreply.github.com>
+Date:   Tue Jul 15 14:48:29 2025 +0900
+
+    Merge pull request #7 from LiveStudy-group/feature/jiho-notfound-page
+    
+    feat(notfound): 404 페이지 반응형 UI 구현
+
+[33mcommit 087dada0a6293ec0c3a8127480448f97973aed8e[m
+Author: seojiho <happyluck0426@gmail.com>
+Date:   Tue Jul 15 14:44:21 2025 +0900
+
+    feat(header): 공통 헤더 컴포넌트 구현
+
+[33mcommit ab4d0f420f676733e1052ea45c2f9d3f42ede993[m[33m ([m[1;32mfeature/jiho-notfound-page[m[33m)[m
+Merge: ab302e6 3e4c589
+Author: seojiho <happyluck0426@gmail.com>
+Date:   Tue Jul 15 14:38:19 2025 +0900
+
+    Merge branch 'dev' of https://github.com/LiveStudy-group/Frontend into feature/jiho-notfound-page
+
+[33mcommit 3e4c589184771ec5a0c491d7d0bec14cac932e4d[m
+Merge: 3afcd1d 1ebfa4f
+Author: Doongiho <114303137+Doongiho@users.noreply.github.com>
+Date:   Tue Jul 15 14:24:48 2025 +0900
+
+    Merge pull request #6 from LiveStudy-group/design/jinwon-landing-page-ui
+    
+    Design/jinwon landing page UI
+
+[33mcommit ab302e697e9006717ad4052d6615dbb05bff08f5[m[33m ([m[1;31morigin/feature/jiho-notfound-page[m[33m)[m
+Author: seojiho <happyluck0426@gmail.com>
+Date:   Tue Jul 15 14:23:32 2025 +0900
+
+    feat(notfound): 404 페이지 반응형 UI 구현
+
+[33mcommit 1ebfa4f646058210f4fccc14b7041dded58831d4[m[33m ([m[1;31morigin/design/jinwon-landing-page-ui[m[33m)[m
+Author: JinwonShen <bosv031999@gmail.com>
+Date:   Tue Jul 15 14:18:22 2025 +0900
+
+    design: global.css 텍스트 수정
+
+[33mcommit c6567216ca7203366ea8d1f10915824236c68e1b[m
+Author: JinwonShen <bosv031999@gmail.com>
+Date:   Tue Jul 15 13:55:45 2025 +0900
+
+    design: landing-page-ui 및 global.css 부분 수정


### PR DESCRIPTION
📌 작업 개요
공통 헤더 컴포넌트(Header)의 스타일을 수정했습니다.

✅ 작업 내용
헤더의 타이틀(LiveStudy) 텍스트 스타일을 headline3_B로 한 단계 증가
로그인 텍스트 스타일을 caption1_M으로 변경
전반적인 레이아웃과 정렬은 기존 구조 유지

🔎 기타 참고사항
디자인 시스템 기준에 맞춰 텍스트 크기 및 스타일 조정
추후 로그인 여부에 따라 다른 UI(유저 이름, 드롭다운 등)로 확장 예정

