### PR TITLE
feat: jinwon Message 모달 및 아이템 컴포넌트 구조 및 타입 정리

### DIFF
--- a/LiveStudy-front/src/components/MessageButton.tsx
+++ b/LiveStudy-front/src/components/MessageButton.tsx
@@ -4,7 +4,7 @@ export default function MessageButton({ onClick }: { onClick: () => void}) {
   return (
     <button
       onClick={onClick}
-      className="fixed bottom-9 right-6 bg-primary-500 p-6 rounded-full border border-gray-300 shadow-lg text-white hover:bg-white hover:text-primary-400">
+      className="fixed bottom-24 right-6 sm:bottom-28 bg-primary-500 p-6 rounded-full border border-gray-300 shadow-lg text-white hover:bg-primary-600">
       <FiMessageSquare className="w-6 h-6" />
     </button>
   )

--- a/LiveStudy-front/src/components/MessageItem.tsx
+++ b/LiveStudy-front/src/components/MessageItem.tsx
@@ -1,0 +1,44 @@
+import type { MessageItemProps } from "../types/Message";
+
+const MessageItem: React.FC<MessageItemProps> = ({
+  username,
+  profileImage,
+  text,
+  time,
+  isMyMessage,
+}) => {
+  return (
+    <div className="flex flex-col">
+      {isMyMessage && (
+        <div className="flex-1 flex items-center mb-2">
+          <img
+            src={profileImage}
+            alt={`${username}의 프로필`}
+            className="w-8 h-8 rounded-full mr-2"
+          />
+          <p className="font-semibold mb-1">{username}</p>
+        </div>
+      )}
+
+      {!isMyMessage && (
+        <div className="flex items-center justify-end mb-2">
+          <p className="font-semibold mb-1">{username}</p>
+          <img 
+            src={profileImage} 
+            alt={`${username}님의 Profile`} 
+            className="w-8 h-8 rounded-full ml-2" 
+          />
+        </div>
+      )}
+
+      <div
+        className={`flex-1 inline-flex flex-row flex-wrap text-sm ${isMyMessage ? 'justify-start' : 'justify-end'}`}
+      >
+        <p className={`px-4 py-2 rounded-lg shadow ${isMyMessage ? 'bg-primary-100' : 'bg-gray-200'} whitespace-pre-wrap break-words`}>{text}</p>
+        <p className={`w-full text-xs text-gray-500 mt-1 ${isMyMessage ? 'ml-2 text-left' : 'mr-2 text-right'}`}>{time}</p>
+      </div>
+    </div>
+  )
+}
+
+export default MessageItem;

--- a/LiveStudy-front/src/components/MessageModal.tsx
+++ b/LiveStudy-front/src/components/MessageModal.tsx
@@ -1,27 +1,43 @@
 import { useEffect, useRef, useState } from "react";
 import { FiMail, FiSend, FiX } from "react-icons/fi";
+import { useAuthStore } from "../store/authStore";
+import MessageItem from "./MessageItem";
+import { sendMessageToServer } from "../lib/api/messageApi";
+import type { MessageItemProps, MessageModalProps } from "../types/Message";
 
-interface MessageModalProps {
-  open: boolean;
-  onClose: () => void;
-}
 
 export default function MessageModal({ open, onClose }: MessageModalProps) {
-  const [messages, setMessage] = useState<string[]>([])
+  const [messages, setMessage] = useState<MessageItemProps[]>([])
   const [input, setInput] = useState("")
   const messageEndRef = useRef<HTMLDivElement>(null);
+  const userInfo = useAuthStore((state) => state.user)
 
   useEffect(() => {
     if(!open) return;
   }, [open])
 
-  const handleSend = () => {
+  const handleSend = async () => {
     if(!input.trim()) return;
 
-    const message = input.trim()
+    // const message = input.trim()
+    const newMessage: MessageItemProps = {
+      id: String(Date.now()),
+      username: String(userInfo?.username),
+      profileImage: "https://picsum.photos/200/300",
+      time: new Date().toLocaleTimeString('ko-KR', {
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
+      text: input.trim(),
+    }
 
-    setMessage(prev => [...prev, message])
-    setInput('')
+    try {
+      await sendMessageToServer(newMessage);
+      setMessage(prev => [...prev, newMessage])
+      setInput('')
+    } catch (error) {
+      console.error('메시지 전송 실패:', error)
+    }
   }
 
   useEffect(() => {
@@ -31,22 +47,26 @@ export default function MessageModal({ open, onClose }: MessageModalProps) {
   if(!open) return null;
 
   return (
-    <div className="fixed bottom-32 right-6 w-[360px] h-2/3 bg-white rounded-lg shadow-xl flex flex-col">
+    <div className="fixed bottom-24 right-2 left-2 m-auto sm:mr-0 sm:bottom-24 sm:right-6 w-full max-w-[360px] h-3/4 sm:h-2/3 bg-white rounded-lg shadow-xl flex flex-col">
       <div className="flex justify-between items-center p-4 border-b border-gray-300">
         <h2 className="flex items-center gap-2 text-body1_M">
           <FiMail className="m-1 text-base" />
           <span>스터디룸 대화방</span>
         </h2>
-        <button onClick={onClose} className="p-1 rounded-sm hover:text-primary-400 hover:bg-gray-100">
+        <button onClick={onClose} className="p-1 rounded-md hover:bg-gray-100">
           <FiX />
         </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-3 py-2 space-y-2 text-sm">
-        {messages.map((msg, i) => (
-          <div key={i} className="bg-gray-100 p-2 rounded">
-            {msg}
-          </div>
+      <div className="flex-1 overflow-y-auto px-3 py-3 space-y-2 text-sm">
+        {messages.map((msg) => (
+            <MessageItem
+            username={msg.username}
+            profileImage={msg.profileImage}
+            text={msg.text}
+            time={msg.time}
+            isMyMessage={true}
+          />        
         ))}
         <div ref={messageEndRef} />
       </div>
@@ -55,13 +75,13 @@ export default function MessageModal({ open, onClose }: MessageModalProps) {
         <input
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && handleSend()}
+          onKeyUp={(e) => e.key === "Enter" && handleSend()}
           className="flex-1 px-4 py-2 border border-gray-300 rounded-lg text-body1_R"
           placeholder="메시지를 입력하세요"
         />
         <button
           onClick={handleSend}
-          className="basic-button-primary h-full text-white border border-gray-300 hover:bg-white hover:text-primary-400"
+          className="basic-button-primary h-full text-white border border-gray-300 hover:bg-primary-600"
         >
           <FiSend />
         </button>

--- a/LiveStudy-front/src/lib/api/messageApi.ts
+++ b/LiveStudy-front/src/lib/api/messageApi.ts
@@ -1,0 +1,18 @@
+import type { MessageItemProps } from "../../types/Message";
+
+export async function sendMessageToServer(message: MessageItemProps) {
+  const response = await fetch('/api/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(message),
+  });
+
+
+  if(!response.ok) {
+    throw new Error('메시지 전송이 실패했습니다.');
+  }
+
+  return response.json();
+}

--- a/LiveStudy-front/src/pages/StudyRoomPage.tsx
+++ b/LiveStudy-front/src/pages/StudyRoomPage.tsx
@@ -3,10 +3,13 @@ import { useEffect, useState } from 'react';
 import Header from '../components/common/Header';
 import Footer from '../components/common/Footer';
 import VideoGrid from '../components/video/VideoGrid';
+import MessageButton from '../components/MessageButton';
+import MessageModal from '../components/MessageModal';
 
 const StudyRoomPage = () => {
   const [token, setToken] = useState('');
   const [identity, setIdentity] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
     // 스터디룸 입장을 위한 토큰을 서버에서 요청
@@ -29,13 +32,13 @@ const StudyRoomPage = () => {
   }, []);
 
   // 토큰이 아직 생성되지 않은 경우 로딩 화면 출력
-  if (!token) {
-    return (
-      <div className="flex items-center justify-center h-screen text-lg">
-        토큰 생성 중입니다. 브라우저 권한을 허용했는지 확인해주세요.
-      </div>
-    );
-  }
+  // if (!token) {
+  //   return (
+  //     <div className="flex items-center justify-center h-screen text-lg">
+  //       토큰 생성 중입니다. 브라우저 권한을 허용했는지 확인해주세요.
+  //     </div>
+  //   );
+  // }
 
   // 디버깅 용 나중에 삭제 예정
   const RoomLogger = () => {
@@ -78,6 +81,10 @@ const StudyRoomPage = () => {
 
           {/* 화상 공유 컴포넌트 */}
           <VideoGrid />
+
+          {/* 메시지 버튼 및 모달 */}
+          <MessageButton onClick={() => setIsModalOpen(true)} />
+          <MessageModal open={isModalOpen} onClose={() => setIsModalOpen(false)} />
         </main>
         
         {/* 공통 푸터 컴포넌트 */}

--- a/LiveStudy-front/src/types/Message.ts
+++ b/LiveStudy-front/src/types/Message.ts
@@ -1,0 +1,13 @@
+export interface MessageItemProps {
+  id?: string;
+  username: string;
+  profileImage: string;
+  text: string;
+  time: string;
+  isMyMessage?: boolean;
+}
+
+export interface MessageModalProps {
+  open: boolean;
+  onClose: () => void;
+}


### PR DESCRIPTION
### 📌 작업 개요
- Chat 메시지 모달 및 아이템 컴포넌트 구조 타입 정리 완료(연동 및 테스트x)

### ✅ 작업 내용
- MessageModal UI 및 로직 정리
- MessageItem 분리 및 timestamp UI 개선
- Message 관련 타입 Message.ts에 정리
- sendMessageToServer() API 함수 생성

### 🔁 관련 이슈
- msw로는 테스트 불가능해 mock-socket으로 테스트 가능한지 알아봐야 할 것 같습니다.
- 위 방법도 안된다고하면 WebSocket 서버를 간단히 구현할 수 있는지 알아보고 가능한 선에서 구현 해보겠습니다.
