### PR TITLE
feat: mock-socket 설치 및 구성, 테스트

### DIFF
--- a/LiveStudy-front/package-lock.json
+++ b/LiveStudy-front/package-lock.json
@@ -35,6 +35,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "mock-socket": "^9.3.1",
         "msw": "^1.3.5",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
@@ -5737,6 +5738,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/ms": {

--- a/LiveStudy-front/package.json
+++ b/LiveStudy-front/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "mock-socket": "^9.3.1",
     "msw": "^1.3.5",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",

--- a/LiveStudy-front/src/components/test/MockMessageTest.tsx
+++ b/LiveStudy-front/src/components/test/MockMessageTest.tsx
@@ -1,0 +1,56 @@
+import { WebSocket } from "mock-socket";
+import { useEffect, useState } from "react";
+import { setupMockSocketServer } from "../../mocks/mockSocket";
+
+
+const MockMessageTest = () => {
+  const [socket, setSocket] = useState<WebSocket | null>(null);
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState<string[]>([]);
+
+  useEffect(() => {
+    setupMockSocketServer();
+
+    const ws = new WebSocket('ws:localhost:1234');
+    setSocket(ws);
+
+    ws.onmessage = (event) => {
+      setMessages((prev) => [...prev, event.data]);
+    };
+
+    return () => {
+      ws.close();
+    }
+  }, [])
+
+  const handleSend = () => {
+    if(socket && input.trim()) {
+      socket.send(input);
+      setInput('');
+    }
+  }
+
+  return (
+    <div className="p-4 border rounded max-w-md mx-auto">
+      <h2 className="font-bold mb-2">💬 MockSocket 테스트</h2>
+      <div className="flex gap-2 mb-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="border px-2 py-1 flex-1"
+          placeholder="메시지를 입력하세요"
+        />
+        <button onClick={handleSend} className="px-4 py-1 bg-blue-500 text-white rounded">
+          전송
+        </button>
+      </div>
+      <ul className="text-sm space-y-1">
+        {messages.map((msg, i) => (
+          <li key={i}>📩 {msg}</li>
+        ))}
+      </ul>
+    </div>
+  )
+};
+
+export default MockMessageTest;

--- a/LiveStudy-front/src/mocks/mockSocket.ts
+++ b/LiveStudy-front/src/mocks/mockSocket.ts
@@ -1,0 +1,25 @@
+import { Server } from 'mock-socket';
+
+let mockServer: Server | null = null;
+
+export const setupMockSocketServer = () => {
+  if(mockServer) return;
+
+  mockServer = new Server('ws://localhost:1234');
+
+  mockServer.on('connection', (socket) => {
+    console.log('[MockSocket] 클라이언트 연결됨');
+
+    socket.on('message', (data) => {
+      console.log('[MockSocket]', data);
+
+      socket.send(`[서버 응답] ${data}`);
+    })
+
+    socket.on('close', () => {
+      console.log('[MockSocket] 연결종료')
+    })
+  })
+  
+  return mockServer;
+}

--- a/LiveStudy-front/src/pages/StudyRoomPage.tsx
+++ b/LiveStudy-front/src/pages/StudyRoomPage.tsx
@@ -84,7 +84,8 @@ const StudyRoomPage = () => {
 
           {/* 메시지 버튼 및 모달 */}
           <MessageButton onClick={() => setIsModalOpen(true)} />
-          <MessageModal open={isModalOpen} onClose={() => setIsModalOpen(false)} />
+          <MessageModal open={isModalOpen} onClose={() => setIsModalOpen(false)} useMock={true} />
+          {/* <MockMessageTest /> */}
         </main>
         
         {/* 공통 푸터 컴포넌트 */}

--- a/LiveStudy-front/src/types/MockMessage.ts
+++ b/LiveStudy-front/src/types/MockMessage.ts
@@ -1,0 +1,5 @@
+export interface MockMessageModalProps {
+  open: boolean;
+  onClose: () => void;
+  useMock?: boolean;
+}


### PR DESCRIPTION
### 📌 작업 개요
- MockSocket 기반 실시간 메시지 테스트 구조 구현

### ✅ 작업 내용
- mock-socket 서버 구성 및 setupMockSocketServer 유틸 추가
- MessageModal에서 useMock 플래그로 WebSocket 연결 분기
- 메시지 전송/수신 흐름 구축 (mock echo 방식)
- JSON 파싱/직렬화 문제 해결
- MessageItem 렌더링 시 key 누락 해결

### 🔁 관련 이슈
- 테스트 계정도 하나 더 만들어서 임시 토큰을 부여해 두 개의 계정을 만들어 테스트를 한번 더 진행해보면 좋을 것 같습니다.
- 테스트는 localStorage 혹은 URL 파라미터로 사용자를 지정해 테스트하는 방법이 있을 것 같아요 ! 