### PR TITLE
Feat/jinwon my page

### DIFF
--- a/LiveStudy-front/src/mocks/handlers.ts
+++ b/LiveStudy-front/src/mocks/handlers.ts
@@ -63,7 +63,7 @@ export const handlers = [
     )
   }),
   
-  rest.post('/api/users/me/avatar', async (req, res, ctx) => {
+  rest.post('/api/user/profile/change/profileImageUrl', async (req, res, ctx) => {
     return res(
       ctx.status(200),
       ctx.json({
@@ -72,8 +72,9 @@ export const handlers = [
     )
   }),
 
-  rest.put('/api/users/me/nickname', async (req, res, ctx) => {
-    const { nickname } = await req.json();
+  // 기존 닉네임 변경 핸들러 제거됨
+  rest.patch('/api/user/profile/change/username', async (req, res, ctx) => {
+    const { nickname, profileImageUrl, titleId } = await req.json();
 
     if (!nickname || nickname.length < 2) {
       return res(
@@ -84,7 +85,14 @@ export const handlers = [
 
     return res(
       ctx.status(200),
-      ctx.json({ message: '닉네임 변경 완료', nickname })
+      ctx.json({
+        user: {
+          userId: 101,
+          nickname,
+          profileImageUrl,
+          title: `칭호-${titleId}`,
+        }
+      })
     );
   }),
 ]

--- a/LiveStudy-front/src/mocks/handlers.ts
+++ b/LiveStudy-front/src/mocks/handlers.ts
@@ -61,5 +61,30 @@ export const handlers = [
       ctx.status(401),
       ctx.json({ message: '이메일 또는 비밀번호가 올바르지 않습니다.'})
     )
-  }) 
+  }),
+  
+  rest.post('/api/users/me/avatar', async (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        imageUrl: `https://picsum.photos/100/100?random=${Date.now()}`,
+      })
+    )
+  }),
+
+  rest.put('/api/users/me/nickname', async (req, res, ctx) => {
+    const { nickname } = await req.json();
+
+    if (!nickname || nickname.length < 2) {
+      return res(
+        ctx.status(400),
+        ctx.json({ message: '닉네임은 2자 이상이어야 합니다.' })
+      );
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({ message: '닉네임 변경 완료', nickname })
+    );
+  }),
 ]

--- a/LiveStudy-front/src/pages/MyPage.tsx
+++ b/LiveStudy-front/src/pages/MyPage.tsx
@@ -7,10 +7,12 @@ import { useAuthStore } from "../store/authStore";
 const titles = ['🥕 꾸준함의 씨앗', '🔥 불타는 집중왕', '🏋🏼‍♂️ 철인 집중력', '📚 스터디 마스터']
 
 export default function MyPage() {
-  const [selectedTitle, setSelectedTitle] = useState(titles[0])
   const { user } = useAuthStore();
+  const [selectedTitle, setSelectedTitle] = useState(titles[0])
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [profileImage, setProfileImage] = useState(user?.avatarUrl || "/img/my-page-profile-image-1.jpg");
+  const [profileImage, setProfileImage] = useState(user?.profileImageUrl || "/img/my-page-profile-image-1.jpg");
+  const [username, setUsername] = useState(user?.username || "");
+  const [isEditingUsername, setIsEditingUsername] = useState(false);
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -20,7 +22,7 @@ export default function MyPage() {
     formData.append("profileImage", file);
 
     try {
-      const res = await fetch("/api/users/me/avatar", {
+      const res = await fetch("/api/user/profile/change/profileImageUrl", {
         method: "POST",
         body: formData,
       });
@@ -30,6 +32,32 @@ export default function MyPage() {
       }
     } catch (error) {
       console.error("이미지 업로드 실패", error);
+    }
+  };
+
+  const handleUsernameSave = async () => {
+    try {
+      const res = await fetch("/api/user/profile/change/username", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          nickname: username,
+          profileImageUrl: profileImage,
+          titleId: titles.indexOf(selectedTitle) + 1, // 칭호 리스트 인덱스를 기반으로 id 생성 (API 요구사항에 맞춤)
+        }),
+      });
+      if (!res.ok) throw new Error("닉네임 업데이트 실패");
+
+      const data = await res.json();
+      if (user) {
+        user.username = data.user.nickname;
+      }
+
+      setIsEditingUsername(false);
+    } catch (err) {
+      console.error("닉네임 저장 실패:", err);
     }
   };
 
@@ -47,7 +75,7 @@ export default function MyPage() {
             <div className="w-full sm:w-auto">
               <h3 className="min-w-[112px] text-body1_M">프로필 이미지</h3>
             </div>
-            <div className="flex-1 flex items-center gap-4">
+            <div className="flex-1 flex items-center justify-between gap-4">
               <img
                 src={profileImage}
                 alt="프로필 이미지"
@@ -73,12 +101,42 @@ export default function MyPage() {
             <div className="w-full sm:w-auto">
               <h3 className="min-w-[112px] text-body1_M">유저 닉네임</h3>
             </div>
-            <div className="flex-1">
-              <p className="text-caption1_M text-primary-500">홍길동</p>
+            <div className="flex-1 flex justify-between items-center gap-4">
+              {isEditingUsername ? (
+                <>
+                  <input
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    className="flex-1 px-3 py-2 border rounded-lg border-gray-300 text-body1_R"
+                  />
+                  <button
+                    onClick={handleUsernameSave}
+                    className="basic-button-primary hover:bg-primary-600 text-white"
+                  >
+                    저장
+                  </button>
+                  <button
+                    onClick={() => {
+                      setUsername(user?.username || "");
+                      setIsEditingUsername(false);
+                    }}
+                    className="basic-button-gray hover:bg-gray-200"
+                  >
+                    취소
+                  </button>
+                </>
+              ) : (
+                <>
+                  <p className="w-full text-caption1_M text-primary-500">{username}</p>
+                  <button
+                    onClick={() => setIsEditingUsername(true)}
+                    className="basic-button-gray hover:bg-gray-200 text-body1_R"
+                  >
+                    닉네임 변경
+                  </button>
+                </>
+              )}
             </div>
-            <button className="basic-button-gray hover:bg-gray-200 text-body1_R">
-              닉네임 변경
-            </button>
           </div>
 
           <div className="flex flex-wrap justify-between items-center gap-3 sm:gap-6">
@@ -86,7 +144,7 @@ export default function MyPage() {
               <h3 className="min-w-[112px] text-body1_M ">이메일 주소</h3>
             </div>
             <div className="flex-1">
-              <p className="text-caption1_M text-primary-500">bosv031999@gmail.com</p>
+              <p className="text-caption1_M text-primary-500">{user?.email}</p>
             </div>
             <button className="basic-button-gray hover:bg-gray-200 text-body1_R">
               이메일 변경

--- a/LiveStudy-front/src/pages/MyPage.tsx
+++ b/LiveStudy-front/src/pages/MyPage.tsx
@@ -1,12 +1,37 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import Header from "../components/common/Header";
 import Footer from "../components/common/Footer";
 import { FiChevronDown } from "react-icons/fi";
+import { useAuthStore } from "../store/authStore";
 
 const titles = ['🥕 꾸준함의 씨앗', '🔥 불타는 집중왕', '🏋🏼‍♂️ 철인 집중력', '📚 스터디 마스터']
 
 export default function MyPage() {
   const [selectedTitle, setSelectedTitle] = useState(titles[0])
+  const { user } = useAuthStore();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [profileImage, setProfileImage] = useState(user?.avatarUrl || "/img/my-page-profile-image-1.jpg");
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const formData = new FormData();
+    formData.append("profileImage", file);
+
+    try {
+      const res = await fetch("/api/users/me/avatar", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await res.json();
+      if (data.imageUrl) {
+        setProfileImage(data.imageUrl);
+      }
+    } catch (error) {
+      console.error("이미지 업로드 실패", error);
+    }
+  };
 
   return (
     <div className="w-full">
@@ -22,12 +47,26 @@ export default function MyPage() {
             <div className="w-full sm:w-auto">
               <h3 className="min-w-[112px] text-body1_M">프로필 이미지</h3>
             </div>
-            <div className="flex-1">
-              <img src="/public/img/my-page-profile-image-1.jpg" alt="프로필 이미지" className="w-10 h-10w-10 bg-gray-300 rounded-full border border-gray-300" />
+            <div className="flex-1 flex items-center gap-4">
+              <img
+                src={profileImage}
+                alt="프로필 이미지"
+                className="w-10 h-10 bg-gray-300 rounded-full border border-gray-300 object-cover"
+              />
+              <input
+                type="file"
+                accept="image/*"
+                ref={fileInputRef}
+                onChange={handleImageChange}
+                className="hidden"
+              />
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="basic-button-gray hover:bg-gray-200 text-body1_R"
+              >
+                프로필 이미지 변경
+              </button>
             </div>
-            <button className="basic-button-gray hover:bg-gray-200 text-body1_R">
-              프로필 이미지 변경
-            </button>
           </div>
           
           <div className="flex flex-wrap justify-between items-center gap-3 sm:gap-6">

--- a/LiveStudy-front/src/store/authStore.ts
+++ b/LiveStudy-front/src/store/authStore.ts
@@ -7,10 +7,11 @@ interface AuthState {
     uid: string;
     email: string;
     username: string;
+    avatarUrl?: string;
   } | null
   token: string | null;
 
-  login: (user: { uid: string; email: string; username: string }, token: string) => void;
+  login: (user: { uid: string; email: string; username: string; avatarUrl?: string }, token: string) => void;
   logout: () => void;
 }
 
@@ -25,8 +26,8 @@ export const useAuthStore = create<AuthState>()(
       },
       token: null,
 
-      login: ({ uid, email, username }: { uid: string; email: string; username: string }, token: string) => {
-        set({ user: { uid, email, username }, token, isLoggedIn: true });
+      login: ({ uid, email, username, avatarUrl }: { uid: string; email: string; username: string; avatarUrl?: string }, token: string) => {
+        set({ user: { uid, email, username, avatarUrl }, token, isLoggedIn: true });
       },
       logout: () => 
         set({ isLoggedIn: false, user: null, token: null }),

--- a/LiveStudy-front/src/store/authStore.ts
+++ b/LiveStudy-front/src/store/authStore.ts
@@ -7,11 +7,13 @@ interface AuthState {
     uid: string;
     email: string;
     username: string;
-    avatarUrl?: string;
+    profileImageUrl?: string;
+    title?: string;
   } | null
   token: string | null;
 
-  login: (user: { uid: string; email: string; username: string; avatarUrl?: string }, token: string) => void;
+  updateUser: (updates: Partial<AuthState["user"]>) => void;
+  login: (user: { uid: string; email: string; username: string; profileImageUrl?: string }, token: string) => void;
   logout: () => void;
 }
 
@@ -23,11 +25,18 @@ export const useAuthStore = create<AuthState>()(
         uid: '',
         email: '',
         username: '',
+        profileImageUrl: '',
+        title: '',
       },
       token: null,
 
-      login: ({ uid, email, username, avatarUrl }: { uid: string; email: string; username: string; avatarUrl?: string }, token: string) => {
-        set({ user: { uid, email, username, avatarUrl }, token, isLoggedIn: true });
+      updateUser: (updates) =>
+        set((state) => ({
+          user: state.user ? { ...state.user, ...updates } : null,
+        })),
+
+      login: ({ uid, email, username, profileImageUrl, title }: { uid: string; email: string; username: string; profileImageUrl?: string, title?: string }, token: string) => {
+        set({ user: { uid, email, username, profileImageUrl, title }, token, isLoggedIn: true });
       },
       logout: () => 
         set({ isLoggedIn: false, user: null, token: null }),


### PR DESCRIPTION
### 📌 작업 개요
- my page 프로필 이미지 변경 기능 구현
- username 변경 기능 구현

### ✅ 작업 내용
- 프로필 이미지와 유저이름 변경 기능 구현
- 로그인/회원가입과 같이 msw 활용해 fake api 연동

### 🔁 관련 이슈
- 현재 api 명세 수정이 필요할 것으로 보입니다 ! username과 nickname이 같이 사용되고 있는데, 다른 이유가 없다면 username으로 통일하는 것이 좋을 것 같습니다.

### ✅ 추후 작업 예정
- 소셜 로그인 기능 구현시, 이메일과 비밀번호 변경 분기(소셜 로그인이 아닐 때에만 변경이 가능하도록)
- 현재 정리된 칭호 확인 후 칭호 기능 구현
- 누적 집중 시간