### PR TITLE
feat(mock): 공개방 입장 API 핸들러 추가

### DIFF
--- a/LiveStudy-front/src/mocks/handlers.ts
+++ b/LiveStudy-front/src/mocks/handlers.ts
@@ -111,4 +111,32 @@ export const handlers = [
       })
     );
   }),
+
+  rest.post('/api/study-room/enter', async (req, res, ctx) => {
+    const { userId, roomId } = await req.json();
+
+    if (!userId || !roomId) {
+      return res(
+        ctx.status(400),
+        ctx.json({ message: 'userId 또는 roomId가 누락되었습니다.' })
+      );
+    }
+
+    if (userId === 'alreadyInRoomUser') {
+      return res(
+        ctx.status(409),
+        ctx.json({ message: '이미 해당 방에 입장 중입니다.' })
+      );
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: 200,
+        roomId,
+        message: '공개방 입장 성공',
+      })
+    );
+  }),
+
 ]

--- a/LiveStudy-front/src/pages/MainPage.tsx
+++ b/LiveStudy-front/src/pages/MainPage.tsx
@@ -1,7 +1,9 @@
-import { useNavigate } from 'react-router-dom';
+import axios, { AxiosError } from 'axios';
 import { createLocalTracks } from 'livekit-client';
+import { useNavigate } from 'react-router-dom';
 import Footer from '../components/common/Footer';
 import Header from '../components/common/Header';
+
 
 const MainPage = () => {
   const navigate = useNavigate();
@@ -31,7 +33,19 @@ const MainPage = () => {
       return;
     }
 
-    navigate('/studyroom/fff');
+    try {
+      const response = await axios.post('/api/study-room/enter', {
+        userId: 'test-user-id',
+        roomId: 'study-room-123',
+      });
+
+      const { roomId } = response.data;
+      navigate(`/studyroom/${roomId}`);
+      
+    }catch (error: unknown) {
+      const err = error as AxiosError<{ message: string }>;
+      alert(err.response?.data?.message ?? '오류가 발생했습니다.');
+    }
   };
 
   return (


### PR DESCRIPTION
📌 작업 개요
- 공개방 입장 API를 Mock Service로 연결

✅ 작업 내용
- /api/study-room/enter POST 핸들러 추가
- 입장 성공 시 status, roomId, message 반환
- 잘못된 요청 시 에러 반환 처리

🔮 향후 개선 방향
- 백엔드 Swagger 배포 후 실제 API로 대체 예정