### PR TITLE
feat: mock-socket 구현 완료

### DIFF
--- a/LiveStudy-front/src/components/MessageItem.tsx
+++ b/LiveStudy-front/src/components/MessageItem.tsx
@@ -3,13 +3,13 @@ import type { MessageItemProps } from "../types/Message";
 const MessageItem: React.FC<MessageItemProps> = ({
   username,
   profileImage,
-  text,
-  time,
+  message,
+  timestamp,
   isMyMessage,
 }) => {
   return (
     <div className="flex flex-col">
-      {isMyMessage && (
+      {!isMyMessage && (
         <div className="flex-1 flex items-center mb-2">
           <img
             src={profileImage}
@@ -20,7 +20,7 @@ const MessageItem: React.FC<MessageItemProps> = ({
         </div>
       )}
 
-      {!isMyMessage && (
+      {isMyMessage && (
         <div className="flex items-center justify-end mb-2">
           <p className="font-semibold mb-1">{username}</p>
           <img 
@@ -32,10 +32,12 @@ const MessageItem: React.FC<MessageItemProps> = ({
       )}
 
       <div
-        className={`flex-1 inline-flex flex-row flex-wrap text-sm ${isMyMessage ? 'justify-start' : 'justify-end'}`}
+        className={`flex-1 inline-flex flex-row flex-wrap text-sm ${isMyMessage ?  'justify-end' : 'justify-start'}`}
       >
-        <p className={`px-4 py-2 rounded-lg shadow ${isMyMessage ? 'bg-primary-100' : 'bg-gray-200'} whitespace-pre-wrap break-words`}>{text}</p>
-        <p className={`w-full text-xs text-gray-500 mt-1 ${isMyMessage ? 'ml-2 text-left' : 'mr-2 text-right'}`}>{time}</p>
+        <p className={`px-4 py-2 rounded-lg shadow ${isMyMessage ? 'bg-primary-100' : 'bg-gray-200'} whitespace-pre-wrap break-words`}>{message}</p>
+        <p className={`w-full text-xs text-gray-500 mt-1 ${isMyMessage ? 'mr-2 text-right' : 'ml-2 text-left' }`}>
+          {new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+        </p>
       </div>
     </div>
   )

--- a/LiveStudy-front/src/lib/api/auth.ts
+++ b/LiveStudy-front/src/lib/api/auth.ts
@@ -18,6 +18,8 @@ interface LoginResponse {
     uid: string;
     email: string;
     username: string;
+    title?: string;
+    profileImageUrl?: string;
     token: string;
   }
 }

--- a/LiveStudy-front/src/lib/api/messageApi.ts
+++ b/LiveStudy-front/src/lib/api/messageApi.ts
@@ -1,18 +1,34 @@
 import type { MessageItemProps } from "../../types/Message";
 
+// 메시지를 REST API를 통해 서버로 전송
 export async function sendMessageToServer(message: MessageItemProps) {
-  const response = await fetch('/api/messages', {
+  const response = await fetch(`/api/study-room/${message.studyroomId}/chat/messages`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(message),
+    body: JSON.stringify({
+      content: message.message,       // 백엔드 명세에 맞게 key를 'content'로 수정
+      senderId: Number(message.senderId), // senderId가 string이면 number로 변환
+      timestamp: message.timestamp,
+    }),
   });
 
-
-  if(!response.ok) {
+  if (!response.ok) {
     throw new Error('메시지 전송이 실패했습니다.');
   }
 
   return response.json();
 }
+
+/*
+  향후 WebSocket 사용 시 아래와 같은 형태로 메시지 전송이 가능
+  const socket = new WebSocket("wss://your-api-domain/ws");
+
+  socket.send(JSON.stringify({
+    studyroomId: message.studyroomId,
+    senderId: message.senderId,
+    content: message.message,
+    timestamp: message.timestamp,
+  }));
+*/

--- a/LiveStudy-front/src/mocks/handlers.ts
+++ b/LiveStudy-front/src/mocks/handlers.ts
@@ -111,4 +111,23 @@ export const handlers = [
       })
     );
   }),
+
+  rest.get('http://localhost:5001/token', (req, res, ctx) => {
+    const identity = req.url.searchParams.get('identity');
+    const roomName = req.url.searchParams.get('roomName');
+
+    if (!identity || !roomName) {
+      return res(
+        ctx.status(400),
+        ctx.json({ error: 'Missing identity or roomName' })
+      );
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        token: `mock-token-for-${identity}-in-${roomName}`,
+      })
+    );
+  }),
 ]

--- a/LiveStudy-front/src/mocks/mockSocket.ts
+++ b/LiveStudy-front/src/mocks/mockSocket.ts
@@ -13,7 +13,7 @@ export const setupMockSocketServer = () => {
     socket.on('message', (data) => {
       console.log('[MockSocket]', data);
 
-      socket.send(`[서버 응답] ${data}`);
+      socket.send(data);
     })
 
     socket.on('close', () => {

--- a/LiveStudy-front/src/types/Message.ts
+++ b/LiveStudy-front/src/types/Message.ts
@@ -1,10 +1,11 @@
 export interface MessageItemProps {
-  id?: string;
+  senderId?: string;
+  studyroomId?: number;
   username: string;
   profileImage: string;
-  text: string;
-  time: string;
-  isMyMessage?: boolean;
+  message: string;
+  timestamp: string;
+  isMyMessage: boolean;
 }
 
 export interface MessageModalProps {


### PR DESCRIPTION
### 📌 작업 개요
- mock-socket 메시지 기능 구현

### ✅ 작업 내용
- 이전에 명세와 다르게 빠져있던 요소 추가
- 부족했던 타입 보완
- messageApi.ts 백엔드 연동을 염두해 수정

### 🔁 관련 이슈
- mock-socket은 msw와 다르게 콘솔 / 네트워크 > WebSocket 유형 > 메시지에 주고받은 메시지의 정보는 알 수 없는게 맞는건가요 ?

