### PR TITLE
feat(studyroom): 스터디룸 퇴장 기능 구현

### DIFF
--- a/LiveStudy-front/src/components/video/VideoGrid.tsx
+++ b/LiveStudy-front/src/components/video/VideoGrid.tsx
@@ -1,10 +1,9 @@
 import { useTracks } from '@livekit/components-react';
 import { Track } from 'livekit-client';
 import { useState } from 'react';
-import { MdReport } from 'react-icons/md';
+import { MdReport, MdVisibility, MdVisibilityOff } from 'react-icons/md';
 import LiveVideoBox from './LiveVideoBox';
-import VideoReportModal from './VideoReportModal'
-import { MdVisibility, MdVisibilityOff } from 'react-icons/md';
+import VideoReportModal from './VideoReportModal';
 
 const VideoGrid = () => {
   const [reportTarget, setReportTarget] = useState<string | null>(null);
@@ -70,7 +69,7 @@ const VideoGrid = () => {
         onClose={closeModal}
       />
 
-    <section className="flex-1 p-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4 overflow-y-auto">
+    <section className="flex-1 px-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4 overflow-y-auto">
       {tracks.map(({ participant }, idx) => {
         const identity = participant.identity;
 

--- a/LiveStudy-front/src/mocks/handlers.ts
+++ b/LiveStudy-front/src/mocks/handlers.ts
@@ -112,6 +112,7 @@ export const handlers = [
     );
   }),
   
+  // 공개방 입장 핸들러
   rest.post('/api/study-room/enter', async (req, res, ctx) => {
     const { userId, roomId } = await req.json();
 
@@ -138,4 +139,23 @@ export const handlers = [
       })
     );
   }),
+
+  // 스터디룸 퇴장 핸들러
+  rest.post('/api/study-rooms/leave', async (req, res, ctx) => {
+    const url = new URL(req.url.toString());
+    const userId = url.searchParams.get('userId');
+
+    if (!userId) {
+      return res(
+        ctx.status(400),
+        ctx.json({ message: 'userId가 필요합니다.' })
+      );
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({ message: '퇴장 성공' })
+    );
+  }),
+
 ]

--- a/LiveStudy-front/src/pages/StudyRoomPage.tsx
+++ b/LiveStudy-front/src/pages/StudyRoomPage.tsx
@@ -1,15 +1,35 @@
 import { LiveKitRoom, useRoomContext } from '@livekit/components-react';
+import axios from 'axios';
 import { useEffect, useState } from 'react';
-import Header from '../components/common/Header';
+import { useNavigate } from 'react-router-dom';
 import Footer from '../components/common/Footer';
-import VideoGrid from '../components/video/VideoGrid';
+import Header from '../components/common/Header';
 import MessageButton from '../components/MessageButton';
 import MessageModal from '../components/MessageModal';
+import VideoGrid from '../components/video/VideoGrid';
 
 const StudyRoomPage = () => {
+  const navigate = useNavigate();
   const [token, setToken] = useState('');
   const [identity, setIdentity] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+
+  // 스터디룸 퇴장 처리
+  const handleLeaveRoom = async () => {
+    try {
+      await axios.post(`/api/study-rooms/leave`, null, {
+        params: {
+          userId: identity, 
+        },
+      });
+
+      navigate('/main');
+    } catch (err) {
+      console.error('퇴장 실패:', err);
+      alert('스터디룸 퇴장 중 오류가 발생했습니다.');
+    }
+  };
 
   useEffect(() => {
     // 스터디룸 입장을 위한 토큰을 서버에서 요청
@@ -77,6 +97,15 @@ const StudyRoomPage = () => {
       {/* 공통 헤더 컴포넌트 */}
         <Header />
 
+      {/* 퇴장하기 버튼 */}
+        <div className="w-full max-w-[1280px] mx-auto flex justify-end p-4">
+          <button
+            onClick={handleLeaveRoom}
+            className="bg-red-500 text-white px-4 py-2 rounded shadow hover:bg-red-600"
+          >
+            퇴장하기
+          </button>
+        </div>
         <main className="flex-1 w-full max-w-[1280px] mx-auto flex overflow-hidden">
 
           {/* 화상 공유 컴포넌트 */}


### PR DESCRIPTION
📌 작업 개요
스터디룸에서 사용자가 퇴장할 수 있는 기능을 구현했습니다.
/api/study-rooms/leave API를 호출하여 서버에 퇴장을 알리고, LiveKit 세션 종료 후 메인 페이지로 안전하게 이동합니다.

✅ 작업 내용
StudyRoomPage.tsx 내 퇴장 로직 추가
handleLeaveRoom() 함수 작성 및 퇴장 버튼 UI 추가
퇴장 API에 대한 MSW(Mock Service Worker) 핸들러 추가

🔮 향후 개선 방향
백엔드 연동은 추후 예정

