### PR TITLE
Feat/jinwon my page

### DIFF
--- a/LiveStudy-front/src/components/common/Header.tsx
+++ b/LiveStudy-front/src/components/common/Header.tsx
@@ -8,7 +8,10 @@ const Header = () => {
 
   const user = useAuthStore((state) => state.user)
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
-  const logout = useAuthStore((state) => state.logout)
+  const logout = useAuthStore((state) => {
+    console.log('[Header] user 정보:', user);
+    return state.logout;
+  })
   const navigate = useNavigate()
 
   const toggleMenu = () => {
@@ -31,6 +34,9 @@ const Header = () => {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
+  console.log('현재 로그인한 유저 정보: ',user)
+  console.log('현재 로그인한 유저 칭호', user?.title?.name)
+
   return (
     <header className="w-full border-b border-gray-100 z-50">
       <div className="max-w-[1280px] mx-auto px-4 py-4 flex justify-between items-center">
@@ -42,13 +48,19 @@ const Header = () => {
         <div className="flex items-center space-x-4">
           {isLoggedIn ? (
             <div className="text-sm text-right">
-            <div>
-              환영합니다. <strong>{user?.username}님 !</strong>
+              <div>
+                <span className="text-caption1_M">환영합니다 !</span>
+                {user?.title?.key === 'no-title' ? (
+                  <span className="text-gray-300 mx-1">대표 칭호를 선택해주세요.</span>
+                ) : (
+                  <span className="text-primary-400 mx-1">{user?.title?.icon} {user?.title?.name}</span>
+                )}
+                <span>{user?.username}님 !</span>
+              </div>
+              <div className="text-xs">
+                오늘 집중 시간 : <strong>02:03:56</strong>
+              </div>
             </div>
-            <div className="text-xs">
-              오늘 집중 시간 : <strong>02:03:56</strong>
-            </div>
-          </div>
           ) : (
             <div className="text-caption1_R text-gray-500 hover:text-primary-400 transition">
               <Link to={'/login'}>로그인</Link>

--- a/LiveStudy-front/src/components/video/VideoGrid.tsx
+++ b/LiveStudy-front/src/components/video/VideoGrid.tsx
@@ -12,8 +12,6 @@ const VideoGrid = () => {
   const [statusColors, setStatusColors] = useState<Record<string, boolean>>({});
   const [hiddenParticipants, setHiddenParticipants] = useState<Record<string, boolean>>({});
 
-
-
   // 신고 제출 처리
   const openModal = (identity: string) => {
     setReportTarget(identity);
@@ -42,8 +40,6 @@ const VideoGrid = () => {
       [identity]: !prev[identity],
     }));
   };
-
-
 
   // 현재 참여 중인 트랙을 가져옴
   const tracks = useTracks([
@@ -103,10 +99,9 @@ const VideoGrid = () => {
                 <LiveVideoBox participant={participant} />
               )}
 
-
               {/* 하단 정보 영역 */}
               <div className="absolute bottom-0 left-0 w-full px-2 py-1 bg-black/40 text-white text-xs flex items-center justify-center">
-               <button
+              <button
                 className="absolute right-8 text-gray-300 hover:text-gray-500"
                 onClick={() => toggleHide(identity)}
               >

--- a/LiveStudy-front/src/lib/api/auth.ts
+++ b/LiveStudy-front/src/lib/api/auth.ts
@@ -18,7 +18,12 @@ interface LoginResponse {
     uid: string;
     email: string;
     username: string;
-    title?: string;
+    title?: {
+      key: string;
+      name: string;
+      description: string;
+      icon: string;
+    };
     profileImageUrl?: string;
     token: string;
   }

--- a/LiveStudy-front/src/mocks/handlers.ts
+++ b/LiveStudy-front/src/mocks/handlers.ts
@@ -79,6 +79,7 @@ export const handlers = [
     )
   }),
   
+  // 프로필 이미지(default Image)
   rest.post('/api/user/profile/change/profileImageUrl', async (req, res, ctx) => {
     return res(
       ctx.status(200),
@@ -111,7 +112,66 @@ export const handlers = [
       })
     );
   }),
-  
+
+  // 이메일 주소 변경
+  rest.patch('/api/user/profile/change/email', async (req, res, ctx) => {
+    const { email } = await req.json();
+
+    if (!email || !email.includes('@')) {
+      return res(
+        ctx.status(400),
+        ctx.json({ message: '올바른 이메일 주소를 입력해주세요.' })
+      );
+    }
+
+    if (email === 'existing@example.com') {
+      return res(
+        ctx.status(409),
+        ctx.json({ message: '이미 사용 중인 이메일입니다.' })
+      );
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        user: {
+          email,
+        }
+      })
+    );
+  }),
+
+  // 비밀번호 변경
+  rest.patch('/api/user/profile/change/password', async (req, res, ctx) => {
+    const { currentPassword, newPassword } = await req.json();
+
+    if (!currentPassword || !newPassword) {
+      return res(
+        ctx.status(400),
+        ctx.json({ message: '현재 비밀번호와 새 비밀번호를 모두 입력해주세요.' })
+      );
+    }
+
+    if (currentPassword !== '1234') {
+      return res(
+        ctx.status(403),
+        ctx.json({ message: '현재 비밀번호가 일치하지 않습니다.' })
+      );
+    }
+
+    if (newPassword.length < 4) {
+      return res(
+        ctx.status(400),
+        ctx.json({ message: '새 비밀번호는 최소 4자 이상이어야 합니다.' })
+      );
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({ message: '비밀번호가 성공적으로 변경되었습니다.' })
+    );
+  }),
+
   rest.post('/api/study-room/enter', async (req, res, ctx) => {
     const { userId, roomId } = await req.json();
 

--- a/LiveStudy-front/src/mocks/handlers.ts
+++ b/LiveStudy-front/src/mocks/handlers.ts
@@ -1,6 +1,138 @@
 import axios from 'axios';
 import { rest } from 'msw';
 
+// 칭호 전체 목록
+const allTitles = [
+  {
+    id: 0,
+    key: 'no-title',
+    name: '대표 칭호를 설정해주세요.',
+    description: '마이페이지에서 칭호를 지정해주세요.',
+    icon: '🙏',
+    isRepresent: true,
+  },
+  {
+    id: 1,
+    key: 'first-login',
+    name: '첫 입장',
+    description: '처음 방에 입장했을 때 취득',
+    icon: '🌱',
+    isRepresent: false,
+  },
+  {
+    id: 2,
+    key: 'night-owl',
+    name: '야행성',
+    description: '밤 10시 이후 30회 이상 접속',
+    icon: '🌙',
+    isRepresent: false,
+  },
+  {
+    id: 3,
+    key: 'report-hunter',
+    name: '청결 헌터',
+    description: '신고 5회 이상 시 취득',
+    icon: '🧹',
+    isRepresent: false,
+  },
+  {
+    id: 4,
+    key: 'focus-beginner',
+    name: 'Focus Beginner',
+    description: '하루 30분 이상 집중 1회',
+    icon: '🧘',
+    isRepresent: false,
+  },
+  {
+    id: 5,
+    key: 'focus-runner',
+    name: 'Focus Runner',
+    description: '하루 1시간 이상 집중, 3일 연속',
+    icon: '🏃',
+    isRepresent: false,
+  },
+  {
+    id: 6,
+    key: 'focus-five',
+    name: 'Focus 좀 치는데?!',
+    description: '50분 이상 타이머 연속 5회 달성',
+    icon: '🔥',
+    isRepresent: false,
+  },
+  {
+    id: 7,
+    key: 'daily-visitor',
+    name: '일일 학습러',
+    description: '언제든 접속하면 취득',
+    icon: '📅',
+    isRepresent: false,
+  },
+  {
+    id: 8,
+    key: 'perfect-attendance-7',
+    name: '개근상',
+    description: '7일 연속 출석',
+    icon: '🎯',
+    isRepresent: false,
+  },
+  {
+    id: 9,
+    key: 'perfect-attendance-30',
+    name: '습관 만드는 길',
+    description: '30일 연속 출석',
+    icon: '🏅',
+    isRepresent: false,
+  },
+  {
+    id: 10,
+    key: 'from-nine',
+    name: 'From 9 Start',
+    description: '매일 오전 9시 정각에 접속, 7일 이상',
+    icon: '⏰',
+    isRepresent: false,
+  },
+  {
+    id: 11,
+    key: 'wide-foot',
+    name: 'Wide Foot',
+    description: '채팅 100회 이상',
+    icon: '💬',
+    isRepresent: false,
+  },
+  {
+    id: 12,
+    key: 'first-hour',
+    name: '첫 걸음도 한 시간부터!',
+    description: '누적 집중 1시간 이상',
+    icon: '⏳',
+    isRepresent: false,
+  },
+  {
+    id: 13,
+    key: 'hundred-focus',
+    name: 'Hundred Focus',
+    description: '누적 집중 100시간 달성',
+    icon: '🏆',
+    isRepresent: false,
+  },
+  {
+    id: 14,
+    key: 'ten-hour-day',
+    name: 'Only Running for day',
+    description: '하루 10시간 이상 집중',
+    icon: '⚡️',
+    isRepresent: false,
+  },
+  {
+    id: 15,
+    key: 'title-collector',
+    name: '칭호 수첩',
+    description: '칭호 10개 이상 획득',
+    icon: '📖',
+    isRepresent: false,
+  },
+];
+
 export const checkDuplicateEmail = async (email: string) => {
   const res = await axios.post('/api/auth/check-email', {email});
   return res.data;
@@ -41,6 +173,8 @@ export const handlers = [
   rest.post('/api/auth/login', async (req, res, ctx) => {
     const { email, password } = await req.json();
 
+    const currentTitle = allTitles.find((t) => t.isRepresent) ?? allTitles[0];
+
     // 테스트용 계정 1
     if(email === 'test1@example.com' && password === '1234') {
       return res(
@@ -51,6 +185,13 @@ export const handlers = [
             uid: 'test-uid-1234',
             email,
             username: '테스트 유저',
+            title: currentTitle?.key ? currentTitle : {
+              id: 0,
+              key: 'no-title',
+              name: '현재 보유한 칭호가 없어요.',
+              description: '마이페이지에서 칭호를 지정해주세요.',
+              icon: '❔',
+            },
             token: 'fake-jwt-token-1'
           }
         })
@@ -67,6 +208,13 @@ export const handlers = [
             uid: 'test-uid-5678',
             email,
             username: '서브 유저',
+            title: currentTitle?.key ? currentTitle : {
+              id: 0,
+              key: 'no-title',
+              name: '현재 보유한 칭호가 없어요.',
+              description: '마이페이지에서 칭호를 지정해주세요.',
+              icon: '❔',
+            },
             token: 'fake-jwt-token-2'
           }
         })
@@ -89,9 +237,9 @@ export const handlers = [
     )
   }),
 
-  // 기존 닉네임 변경 핸들러 제거됨
+  // 기존 닉네임 변경 핸들러
   rest.patch('/api/user/profile/change/username', async (req, res, ctx) => {
-    const { nickname, profileImageUrl, titleId } = await req.json();
+    const { nickname, profileImageUrl } = await req.json();
 
     if (!nickname || nickname.length < 2) {
       return res(
@@ -107,7 +255,6 @@ export const handlers = [
           userId: 101,
           nickname,
           profileImageUrl,
-          title: `칭호-${titleId}`,
         }
       })
     );
@@ -169,6 +316,33 @@ export const handlers = [
     return res(
       ctx.status(200),
       ctx.json({ message: '비밀번호가 성공적으로 변경되었습니다.' })
+    );
+  }),
+
+  // 칭호 목록 조회
+  rest.get('/api/user/titles', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        titles: allTitles,
+      })
+    );
+  }),
+
+  // 대표 칭호 설정 (선택사항)
+  rest.patch('/api/user/titles/represent', async (req, res, ctx) => {
+    const { titleKey } = await req.json();
+    const selected = allTitles.find((t) => t.key === titleKey);
+    if (selected) {
+      allTitles.forEach((t) => (t.isRepresent = false));
+      selected.isRepresent = true;
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        message: `"${selected?.name}" 칭호가 대표로 설정되었습니다.`,
+      })
     );
   }),
 

--- a/LiveStudy-front/src/pages/MyPage.tsx
+++ b/LiveStudy-front/src/pages/MyPage.tsx
@@ -13,6 +13,11 @@ export default function MyPage() {
   const [profileImage, setProfileImage] = useState(user?.profileImageUrl || "/img/my-page-profile-image-1.jpg");
   const [username, setUsername] = useState(user?.username || "");
   const [isEditingUsername, setIsEditingUsername] = useState(false);
+  const [isEditingEmail, setIsEditingEmail] = useState(false);
+  const [email, setEmail] = useState(user?.email || "");
+  const [isEditingPassword, setIsEditingPassword] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -61,10 +66,50 @@ export default function MyPage() {
     }
   };
 
+  const handleEmailSave = async () => {
+    try {
+      const res = await fetch('api/user/profile/change/email', {
+        method: "PATCH",
+        headers: { "Content-type" : "application/json"},
+        body: JSON.stringify({ email }),
+      });
+      if(!res.ok) throw new Error("이메일 변경 실패");
+      const data = await res.json();
+
+      if(user) user.email = data.user.email;
+
+      setIsEditingEmail(false);
+    } catch (error) {
+      console.error("이메일 저장 실패:", error);
+    }
+  }
+
+  const handlePasswordSave = async () => {
+    try {
+      const res = await fetch("/api/user/profile/change/password", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          currentPassword,
+          newPassword,
+        }),
+      });
+      if (!res.ok) throw new Error("비밀번호 변경 실패");
+
+      setCurrentPassword("");
+      setNewPassword("");
+      setIsEditingPassword(false);
+    } catch (error) {
+      console.error("비밀번호 저장 실패:", error);
+    }
+  };
+
   return (
     <div className="w-full">
       <Header />
-      <section className="max-w-[1280px] sm:h-[calc(100vh-156px)] m-auto p-6">
+      <section className="max-w-[1280px] sm:min-h-[calc(100vh-156px)] m-auto p-6">
         <h1 className="text-headline3_B">마이페이지</h1>
         <div className="flex flex-col gap-6 pt-6">
           <h2 className="font-semibold">유저 정보</h2>
@@ -143,21 +188,91 @@ export default function MyPage() {
             <div className="w-full sm:w-auto">
               <h3 className="min-w-[112px] text-body1_M ">이메일 주소</h3>
             </div>
-            <div className="flex-1">
-              <p className="text-caption1_M text-primary-500">{user?.email}</p>
+            <div className="flex-1 flex justify-between items-center gap-4">
+              {isEditingEmail ? (
+                <>
+                  <input
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="flex-1 px-3 py-2 border rounded-lg border-gray-300 text-body1_R"
+                  />
+                  <button
+                    onClick={handleEmailSave}
+                    className="basic-button-primary hover:bg-primary-600 text-white"
+                  >
+                    저장
+                  </button>
+                  <button
+                    onClick={() => {
+                      setEmail(user?.email || "");
+                      setIsEditingEmail(false);
+                    }}
+                    className="basic-button-gray hover:bg-gray-200"
+                  >
+                    취소
+                  </button>
+                </>
+              ) : (
+                <>
+                  <p className="w-full text-caption1_M text-primary-500">{email}</p>
+                  <button
+                    onClick={() => setIsEditingEmail(true)}
+                    className="basic-button-gray hover:bg-gray-200 text-body1_R"
+                  >
+                    이메일 변경
+                  </button>
+                </>
+              )}
             </div>
-            <button className="basic-button-gray hover:bg-gray-200 text-body1_R">
-              이메일 변경
-            </button>
           </div>
 
-          <div className="flex justify-between items-center">
-            <div>
-              <h3 className="min-w-[112px] text-body1_M ">비밀번호</h3>
+          <div className="flex flex-wrap justify-between items-center gap-3 sm:gap-6">
+            <div className="w-full sm:w-auto">
+              <h3 className="min-w-[112px] text-body1_M">비밀번호</h3>
             </div>
-            <button className="basic-button-gray hover:bg-gray-200 text-body1_R">
-              비밀번호 변경
-            </button>
+            <div className="flex-1 flex justify-end items-center gap-4">
+              {isEditingPassword ? (
+                <>
+                  <input
+                    type="password"
+                    placeholder="현재 비밀번호"
+                    value={currentPassword}
+                    onChange={(e) => setCurrentPassword(e.target.value)}
+                    className="flex-1 px-3 py-2 border rounded-lg border-gray-300 text-body1_R"
+                  />
+                  <input
+                    type="password"
+                    placeholder="새 비밀번호"
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    className="flex-1 px-3 py-2 border rounded-lg border-gray-300 text-body1_R"
+                  />
+                  <button
+                    onClick={handlePasswordSave}
+                    className="basic-button-primary hover:bg-primary-600 text-white"
+                  >
+                    저장
+                  </button>
+                  <button
+                    onClick={() => {
+                      setCurrentPassword("");
+                      setNewPassword("");
+                      setIsEditingPassword(false);
+                    }}
+                    className="basic-button-gray hover:bg-gray-200"
+                  >
+                    취소
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={() => setIsEditingPassword(true)}
+                  className="basic-button-gray hover:bg-gray-200 text-body1_R"
+                >
+                  비밀번호 변경
+                </button>
+              )}
+            </div>
           </div>
         </div>
 

--- a/LiveStudy-front/src/store/authStore.ts
+++ b/LiveStudy-front/src/store/authStore.ts
@@ -8,12 +8,42 @@ interface AuthState {
     email: string;
     username: string;
     profileImageUrl?: string;
-    title?: string;
-  } | null
+    title?: {
+      key: string;
+      name: string;
+      description: string;
+      icon: string;
+      isRepresent: boolean;
+    };
+  } | null;
   token: string | null;
 
+  titleList?: {
+    key: string;
+    name: string;
+    description: string;
+    icon: string;
+    isRepresent: boolean;
+  }[];
+  fetchTitleList?: () => void;
+
   updateUser: (updates: Partial<AuthState["user"]>) => void;
-  login: (user: { uid: string; email: string; username: string; profileImageUrl?: string }, token: string) => void;
+  login: (
+    user: {
+      uid: string;
+      email: string;
+      username: string;
+      profileImageUrl?: string;
+      title?: {
+        key: string;
+        name: string;
+        description: string;
+        icon: string;
+        isRepresent: boolean;
+      };
+    },
+    token: string
+  ) => void;
   logout: () => void;
 }
 
@@ -26,20 +56,67 @@ export const useAuthStore = create<AuthState>()(
         email: '',
         username: '',
         profileImageUrl: '',
-        title: '',
       },
       token: null,
+      titleList: [],
 
       updateUser: (updates) =>
         set((state) => ({
-          user: state.user ? { ...state.user, ...updates } : null,
+          user: state.user
+            ? {
+                ...state.user,
+                ...updates,
+                title: updates?.title
+                  ? { ...state.user.title, ...updates.title }
+                  : state.user.title,
+              }
+            : null,
         })),
 
-      login: ({ uid, email, username, profileImageUrl, title }: { uid: string; email: string; username: string; profileImageUrl?: string, title?: string }, token: string) => {
-        set({ user: { uid, email, username, profileImageUrl, title }, token, isLoggedIn: true });
+      login: (
+        { uid, email, username, profileImageUrl, title }: {
+          uid: string;
+          email: string;
+          username: string;
+          profileImageUrl?: string;
+          title?: {
+            key: string;
+            name: string;
+            description: string;
+            icon: string;
+            isRepresent: boolean;
+          };
+        },
+        token: string
+      ) => {
+        const defaultTitle = {
+          key: "no-title",
+          name: "대표 칭호를 설정해주세요!",
+          description: "마이페이지에서 대표 칭호를 선택해주세요.",
+          icon: "🙏",
+          isRepresent: true,
+        };
+
+        set({
+          user: {
+            uid,
+            email,
+            username,
+            profileImageUrl,
+            title: title || defaultTitle,
+          },
+          token,
+          isLoggedIn: true,
+        });
       },
       logout: () => 
         set({ isLoggedIn: false, user: null, token: null }),
+
+      fetchTitleList: async () => {
+        const res = await fetch("/api/titles");
+        const data = await res.json();
+        set({ titleList: data });
+      },
     }),
     {
       name: "live-study-auth-storage",


### PR DESCRIPTION
### 📌 작업 개요
- 마이페이지 이메일 변경, 비밀번호 변경 로직 구현
- 칭호 목록 및 대표 칭호 선택 기능 구현(mock)

### ✅ 작업 내용
- 마이페이지의 이메일과 비밀번호 변경 기능 구현
- 칭호 목록과 대표 칭호 선택 기능을 구현하는데 mock 데이터로 구현하다보니 전역적으로 관리하는데 이슈가 많았던 것 같습니다. 현재는 시간이 없어 이슈를 해결하기보다는 mock으로서의 UI 구현과, 백엔드 연동시에 리팩토링을 준비하는 것이 더 낫다고 판단해 다음과 같이 구현했습니다.
