### PR TITLE
feat: user message 차단기능(채팅 숨김) 구현

### DIFF
--- a/LiveStudy-front/src/App.tsx
+++ b/LiveStudy-front/src/App.tsx
@@ -9,6 +9,7 @@ import JoinPage from './pages/JoinPage';
 import MyPage from './pages/MyPage';
 import EmailLoginPage from './pages/EmailLoginPage';
 import PrivateRoute from './routes/PrivateRoute';
+import BlockTestPage from './components/TestMessagePage';
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
       <Route path='/join' element={<JoinPage />} />
       <Route path='*' element={<NotFoundPage />} />
       <Route path='test-page' element={<TestPage />} />
+      <Route path='block-test-page' element={<BlockTestPage />} />
 
       {/* 보호 라우트 */}
       <Route path='/main' element={

--- a/LiveStudy-front/src/components/MessageItem.tsx
+++ b/LiveStudy-front/src/components/MessageItem.tsx
@@ -1,26 +1,86 @@
+import { useState } from "react";
 import type { MessageItemProps } from "../types/Message";
+import { useBlockUserStore } from "../store/blockUserStore";
 
 const MessageItem: React.FC<MessageItemProps> = ({
+  senderId = '',
   username,
   profileImage,
   message,
   timestamp,
   isMyMessage,
+  isContinuous = false,
+  prevMessageSenderId,
+  prevMessageText,
 }) => {
+  const [openUserInfo, setOpenUserInfo] = useState(false);
+  const { isBlocked, blockUser } = useBlockUserStore();
+  const blocked = senderId ? isBlocked(senderId) : false;
+
+  const isDuplicateBlockedMessage =
+    blocked &&
+    prevMessageSenderId === senderId &&
+    prevMessageText === "(차단한 유저의 메시지입니다.)";
+
+  console.log("[Block Check]", {
+    senderId,
+    blocked,
+    prevMessageSenderId,
+    prevMessageText,
+    isDuplicateBlockedMessage
+  });
+
+  if (isDuplicateBlockedMessage) {
+    return null;
+  }
+
+  console.log("[MessageItem]", {
+    senderId,
+    isBlocked: blocked,
+    isContinuous,
+    isMyMessage,
+    message,
+    isDuplicateBlockedMessage
+  });
+
+  const toggleMenu = () => {
+    setOpenUserInfo((prev) => !prev);
+  };
+
+  const handleBlock = () => {
+    if (blocked) {
+      // 차단 해제
+      useBlockUserStore.getState().unblockUser(senderId);
+    } else {
+      // 차단
+      blockUser(senderId);
+    }
+    setOpenUserInfo(false);
+  };
+
   return (
     <div className="flex flex-col">
-      {!isMyMessage && (
-        <div className="flex-1 flex items-center mb-2">
-          <img
-            src={profileImage}
-            alt={`${username}의 프로필`}
-            className="w-8 h-8 rounded-full mr-2"
-          />
-          <p className="font-semibold mb-1">{username}</p>
+      {!isMyMessage && !isContinuous && (
+        <div className="relative">
+          <div className="flex-1 flex items-center mb-2 cursor-pointer" onClick={toggleMenu}>
+            <img
+              src={profileImage}
+              alt={`${username}의 프로필`}
+              className="w-8 h-8 rounded-full mr-2"
+            />
+            <p className="font-semibold mb-1">{username}</p>
+          </div>
+          {openUserInfo && (
+            <div className="absolute top-6 left-8 mt-2 px-4 py-2 text-xs bg-white border border-gray-100 rounded-md shadow-md hover:bg-gray-100 cursor-pointer z-10">
+              <ul>
+                <li onClick={handleBlock}>{blocked ? "차단 해지하기" : "차단하기"}</li>
+              </ul>
+            </div>
+          )}
         </div>
       )}
 
-      {isMyMessage && (
+      {isMyMessage && !isContinuous && (
         <div className="flex items-center justify-end mb-2">
           <p className="font-semibold mb-1">{username}</p>
           <img 
@@ -34,7 +94,9 @@ const MessageItem: React.FC<MessageItemProps> = ({
       <div
         className={`flex-1 inline-flex flex-row flex-wrap text-sm ${isMyMessage ?  'justify-end' : 'justify-start'}`}
       >
-        <p className={`px-4 py-2 rounded-lg shadow ${isMyMessage ? 'bg-primary-100' : 'bg-gray-200'} whitespace-pre-wrap break-words`}>{message}</p>
+        <p className={`px-4 py-2 rounded-lg shadow ${isMyMessage ? 'bg-primary-100' : 'bg-gray-200'} whitespace-pre-wrap break-words`}>
+          {blocked ? "(차단한 유저의 메시지입니다.)" : message}
+        </p>
         <p className={`w-full text-xs text-gray-500 mt-1 ${isMyMessage ? 'mr-2 text-right' : 'ml-2 text-left' }`}>
           {new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
         </p>

--- a/LiveStudy-front/src/components/TestMessagePage.tsx
+++ b/LiveStudy-front/src/components/TestMessagePage.tsx
@@ -1,0 +1,54 @@
+// src/pages/BlockTestPage.tsx
+import MessageItem from '../components/MessageItem';
+import { useEffect } from 'react';
+import { useBlockUserStore } from '../store/blockUserStore';
+
+const dummyMessages = [
+  {
+    senderId: 'user-a',
+    username: '홍길동',
+    profileImage: 'https://via.placeholder.com/40',
+    message: '안녕하세요',
+    timestamp: new Date().toISOString(),
+    isMyMessage: false,
+    isContinuous: false,
+  },
+  {
+    senderId: 'user-a',
+    username: '홍길동',
+    profileImage: 'https://via.placeholder.com/40',
+    message: '이 메시지도 보이면 안 돼요',
+    timestamp: new Date().toISOString(),
+    isMyMessage: false,
+    isContinuous: true,
+  },
+  {
+    senderId: 'user-me',
+    username: '나',
+    profileImage: 'https://via.placeholder.com/40',
+    message: '나는 차단하지 않았어',
+    timestamp: new Date().toISOString(),
+    isMyMessage: true,
+    isContinuous: false,
+  }
+];
+
+const BlockTestPage = () => {
+  const blockUser = useBlockUserStore((state) => state.blockUser);
+
+  useEffect(() => {
+    // user-a를 차단한 상태로 시작
+    blockUser('user-a');
+  }, [blockUser]);
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-bold mb-4">차단 메시지 테스트</h2>
+      {dummyMessages.map((msg, index) => (
+        <MessageItem key={index} {...msg} />
+      ))}
+    </div>
+  );
+};
+
+export default BlockTestPage;

--- a/LiveStudy-front/src/store/blockUserStore.ts
+++ b/LiveStudy-front/src/store/blockUserStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface BlockUserState {
+  blockedUserIds: string[];
+  blockUser: (uid: string) => void;
+  unblockUser: (uid: string) => void;
+  isBlocked: (uid: string) => boolean;
+}
+
+export const useBlockUserStore = create<BlockUserState>()(
+  persist(
+    (set, get) => ({
+      blockedUserIds: [],
+      blockUser: (uid) =>
+        set((state) => ({
+          blockedUserIds: [...state.blockedUserIds, uid],
+        })),
+      unblockUser: (uid) =>
+        set((state) => ({
+          blockedUserIds: state.blockedUserIds.filter((id) => id !== uid),
+        })),
+      isBlocked: (uid) => get().blockedUserIds.includes(uid),
+    }),
+    {
+      name: "blocked-user-storage",
+    }
+  )
+);

--- a/LiveStudy-front/src/types/Message.ts
+++ b/LiveStudy-front/src/types/Message.ts
@@ -1,11 +1,15 @@
 export interface MessageItemProps {
-  senderId?: string;
+  senderId: string;
   studyroomId?: number;
   username: string;
   profileImage: string;
   message: string;
   timestamp: string;
   isMyMessage: boolean;
+  isContinuous?: boolean;
+  blocked?: boolean;
+  prevMessageSenderId?: string;
+  prevMessageText?: string;
 }
 
 export interface MessageModalProps {


### PR DESCRIPTION
### 📌 작업 개요
- 스터디룸 내 상대방 채팅 차단 기능 구현

### ✅ 작업 내용
- 채팅 모달에서 차단하고자하는 상대의 프로필 혹은 닉네임을 클릭하면 차단하기 모달이 나타남
- blocked 상태가 아닐 때에는 "차단하기" blocked 상태일 때에는 "차단 해지하기" 버튼 출력
- 차단하기 클릭시 상대방 채팅이 "(차단한 유저의 메시지입니다.)" 채팅으로 가려짐

### 🔁 관련 이슈
- 상대방이 연속된 채팅을 보낼 때, 차단한 유저이거나 도배성 메시지라면 하나의 메시지만 출력되게 구현하고자 했으나, 어려움이 있었음. 시간 관계상 배포가 우선이라고 판단해 스킵하고 이후 리펙토링 예정