### PR TITLE
Feat/jiho base url

### DIFF
--- a/LiveStudy-front/.env
+++ b/LiveStudy-front/.env
@@ -1,0 +1,4 @@
+VITE_API_BASE_URL=https://live-study.com/api
+VITE_GOOGLE_CLIENT_ID=52046583081-ihlomiiibi4iggbs6bkicd768mfkg2jq.apps.googleusercontent.com
+VITE_KAKAO_CLIENT_ID=98521588a69d7a6c3945fb4307caebad
+VITE_NAVER_CLIENT_ID=bOs4Dsopdpf7V6UC3B6n

--- a/LiveStudy-front/src/lib/constants/authUrls.ts
+++ b/LiveStudy-front/src/lib/constants/authUrls.ts
@@ -1,0 +1,29 @@
+import { BASE_API_URL } from './baseUrl';
+
+export const GOOGLE_AUTH_URL =
+  'https://accounts.google.com/o/oauth2/v2/auth?' +
+  new URLSearchParams({
+    client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID!,
+    redirect_uri: `${BASE_API_URL}/auth/oauth2/callback/google`,
+    response_type: 'code',
+    scope: 'openid profile email',
+    access_type: 'offline',
+    prompt: 'consent',
+  });
+
+export const KAKAO_AUTH_URL =
+  'https://kauth.kakao.com/oauth/authorize?' +
+  new URLSearchParams({
+    client_id: import.meta.env.VITE_KAKAO_CLIENT_ID!,
+    redirect_uri: `${BASE_API_URL}/auth/oauth2/callback/kakao`,
+    response_type: 'code',
+  });
+
+export const NAVER_AUTH_URL =
+  'https://nid.naver.com/oauth2.0/authorize?' +
+  new URLSearchParams({
+    client_id: import.meta.env.VITE_NAVER_CLIENT_ID!,
+    redirect_uri: `${BASE_API_URL}/auth/oauth2/callback/naver`,
+    response_type: 'code',
+    state: 'liveStudyStateToken',
+  });

--- a/LiveStudy-front/src/lib/constants/baseUrl.ts
+++ b/LiveStudy-front/src/lib/constants/baseUrl.ts
@@ -1,0 +1,1 @@
+export const BASE_API_URL = 'https://live-study.com/api';


### PR DESCRIPTION
📌 작업 개요
API 기본 주소(base URL)를 공통 상수 파일로 분리하여 중복 제거 및 유지보수 용이성 향상

✅ 작업 내용
기존 코드에서 사용하던 API 주소 하드코딩 제거
authUrls.ts 등 외부 모듈에서 BASE_API_URL을 import 하도록 변경
