### PR TITLE
Feat/jiho social login api

### DIFF
--- a/LiveStudy-front/.env
+++ b/LiveStudy-front/.env
@@ -1,0 +1,4 @@
+VITE_API_BASE_URL=https://live-study.com/api
+VITE_GOOGLE_CLIENT_ID=52046583081-ihlomiiibi4iggbs6bkicd768mfkg2jq.apps.googleusercontent.com
+VITE_KAKAO_CLIENT_ID=98521588a69d7a6c3945fb4307caebad
+VITE_NAVER_CLIENT_ID=bOs4Dsopdpf7V6UC3B6n

--- a/LiveStudy-front/src/lib/constants/authUrls.ts
+++ b/LiveStudy-front/src/lib/constants/authUrls.ts
@@ -1,0 +1,29 @@
+import { BASE_API_URL } from './baseUrl';
+
+export const GOOGLE_AUTH_URL =
+  'https://accounts.google.com/o/oauth2/v2/auth?' +
+  new URLSearchParams({
+    client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID!,
+    redirect_uri: `${BASE_API_URL}/auth/oauth2/callback/google`,
+    response_type: 'code',
+    scope: 'openid profile email',
+    access_type: 'offline',
+    prompt: 'consent',
+  });
+
+export const KAKAO_AUTH_URL =
+  'https://kauth.kakao.com/oauth/authorize?' +
+  new URLSearchParams({
+    client_id: import.meta.env.VITE_KAKAO_CLIENT_ID!,
+    redirect_uri: `${BASE_API_URL}/auth/oauth2/callback/kakao`,
+    response_type: 'code',
+  });
+
+export const NAVER_AUTH_URL =
+  'https://nid.naver.com/oauth2.0/authorize?' +
+  new URLSearchParams({
+    client_id: import.meta.env.VITE_NAVER_CLIENT_ID!,
+    redirect_uri: `${BASE_API_URL}/auth/oauth2/callback/naver`,
+    response_type: 'code',
+    state: 'liveStudyStateToken',
+  });

--- a/LiveStudy-front/src/lib/constants/baseUrl.ts
+++ b/LiveStudy-front/src/lib/constants/baseUrl.ts
@@ -1,0 +1,1 @@
+export const BASE_API_URL = 'https://live-study.com/api';

--- a/LiveStudy-front/src/pages/LoginPage.tsx
+++ b/LiveStudy-front/src/pages/LoginPage.tsx
@@ -1,6 +1,8 @@
-import { Link } from "react-router-dom"
+import { Link } from "react-router-dom";
+import { GOOGLE_AUTH_URL, KAKAO_AUTH_URL, NAVER_AUTH_URL } from '../lib/constants/authUrls';
 
 export default function LoginPage() {
+ 
   return (
     <div className="min-h-screen flex items-center justify-center px-6">
       <section className="w-full max-w-sm flex flex-col items-center">
@@ -19,9 +21,27 @@ export default function LoginPage() {
           <button className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200">
             <Link to={'/email-login'}>Email 로그인</Link>
           </button>
-          <button className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200">Google 로그인</button>
-          <button className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200">Kakao 로그인</button>
-          <button className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200">Naver 로그인</button>
+           
+          <a
+            href={GOOGLE_AUTH_URL}
+            className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200 text-center"
+          >
+            Google 로그인
+          </a>
+
+          <a
+            href={KAKAO_AUTH_URL}
+            className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200 text-center"
+          >
+            Kakao 로그인
+          </a>
+
+          <a
+            href={NAVER_AUTH_URL}
+            className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200 text-center"
+          >
+            Naver 로그인
+          </a>
         </div>
       </section>
     </div>


### PR DESCRIPTION
📌 작업 개요
소셜 로그인 URL 생성을 상수 파일로 분리하고 .env 기반으로 구성하도록 개선

✅ 작업 내용
Google / Kakao / Naver 로그인 URL을 new URLSearchParams 방식으로 정의
각 redirect_uri는 BASE_API_URL 기준으로 구성