### PR TITLE
Dev

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ VITE_API_BASE_URL=https://api.live-study.com
 # Mock API 사용 여부 (개발환경 전용)
 # true: Mock API 사용 (백엔드 없이 개발)
 # false 또는 미설정: 실제 백엔드 API 사용 (기본값)
-VITE_USE_MOCK=true
+VITE_USE_MOCK=false
 
 # 개발환경 구분
 VITE_NODE_ENV=development

--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ VITE_API_BASE_URL=https://api.live-study.com
 # Mock API 사용 여부 (개발환경 전용)
 # true: Mock API 사용 (백엔드 없이 개발)
 # false 또는 미설정: 실제 백엔드 API 사용 (기본값)
-VITE_USE_MOCK=false
+VITE_USE_MOCK=true
 
 # 개발환경 구분
 VITE_NODE_ENV=development

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,16 @@
 import { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import NotFoundPage from './pages/Error/NotFoundPage';
-import LandingPage from './pages/LandingPage';
-import StudyRoomPage from './pages/StudyRoomPage';
-import MainPage from './pages/MainPage';
-import TestPage from './pages/TestPage';
-import LoginPage from './pages/LoginPage';
-import JoinPage from './pages/JoinPage';
-import MyPage from './pages/MyPage';
-import EmailLoginPage from './pages/EmailLoginPage';
-import PrivateRoute from './routes/PrivateRoute';
 import BlockTestPage from './components/TestMessagePage';
+import EmailLoginPage from './pages/EmailLoginPage';
+import NotFoundPage from './pages/Error/NotFoundPage';
+import JoinPage from './pages/JoinPage';
+import LandingPage from './pages/LandingPage';
+import LoginPage from './pages/LoginPage';
+import MainPage from './pages/MainPage';
+import MyPage from './pages/MyPage';
+import StudyRoomPage from './pages/StudyRoomPage';
+import TestPage from './pages/TestPage';
+import PrivateRoute from './routes/PrivateRoute';
 import { useAuthStore } from './store/authStore';
 
 function App() {

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -50,12 +50,12 @@ const Header = () => {
             <div className="text-sm text-right">
               <div>
                 <span className="text-caption1_M">환영합니다 !</span>
-                {user?.title?.key === 'no-title' ? (
-                  <span className="text-gray-300 mx-1">대표 칭호를 선택해주세요.</span>
+                {user?.title?.key && user?.title?.key !== 'no-title' && user?.title?.name && user?.title?.name !== '대표 칭호를 설정해주세요!' ? (
+                  <span className="text-primary-400 mx-1 font-medium">{user?.title?.icon} {user?.title?.name}</span>
                 ) : (
-                  <span className="text-primary-400 mx-1">{user?.title?.icon} {user?.title?.name}</span>
+                  <span className="text-gray-300 mx-1">대표 칭호를 선택해주세요.</span>
                 )}
-                <span>{user?.nickname}님 !</span>
+                <span className="font-medium">{user?.nickname}님 !</span>
               </div>
               <div className="text-xs">
                 오늘 집중 시간 : <strong>02:03:56</strong>

--- a/src/lib/api/axios.ts
+++ b/src/lib/api/axios.ts
@@ -1,7 +1,10 @@
 import axios from 'axios';
 
+// 환경변수가 없으면 기본값 사용
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL, // 환경변수 사용!
+  baseURL: API_BASE_URL,
   // withCredentials: true,
   timeout: 10000,
   headers: {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,8 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './styles/global.css';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import App from './App.tsx';
+import './styles/global.css';
 
 (async () => {
   // ========================================

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -221,6 +221,30 @@ export const handlers = [
       );
     }
 
+    // 회원가입한 계정으로도 로그인 가능하도록 허용
+    // 실제로는 회원가입 시 저장된 계정 정보를 확인해야 함
+    if(email && password && password.length >= 6) {
+      return res(
+        ctx.status(200),
+        ctx.json({
+          message: '로그인 성공',
+          user: {
+            uid: `user-${Date.now()}`,
+            email,
+            nickname: email.split('@')[0],
+            title: currentTitle?.key ? currentTitle : {
+              id: 0,
+              key: 'no-title',
+              name: '현재 보유한 칭호가 없어요.',
+              description: '마이페이지에서 칭호를 지정해주세요.',
+              icon: '❔',
+            },
+            token: `fake-jwt-token-${Date.now()}`
+          }
+        })
+      );
+    }
+
     return res(
       ctx.status(401),
       ctx.json({ message: '이메일 또는 비밀번호가 올바르지 않습니다.'})

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,7 +1,0 @@
-export default function RegisterPage() {
-  return (
-    <section>
-      <h1>RegisterPage</h1>
-    </section>
-  );
-}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -68,9 +68,7 @@ export const useAuthStore = create<AuthState>()(
             ? {
                 ...state.user,
                 ...updates,
-                title: updates?.title
-                  ? { ...state.user.title, ...updates.title }
-                  : state.user.title,
+                title: updates?.title || state.user.title,
               }
             : null,
         })),

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -168,4 +168,38 @@ export interface UserTitleResponse {
   description: string;
   representative: boolean;
   isRepresentative: boolean;
+}
+
+// ============================================
+// 칭호 관련 타입 정의 (새로 추가)
+// ============================================
+
+// 칭호 정보 타입
+export interface Title {
+  key: string;
+  name: string;
+  description: string;
+  icon: string;
+  type: string;
+  acquiredAt: string;
+  isRepresent: boolean;
+}
+
+// 칭호 목록 조회 응답 타입
+export interface TitlesApiResponse {
+  success: boolean;
+  titles?: Title[];
+  message: string;
+}
+
+// 대표 칭호 변경 요청 타입
+export interface UpdateRepresentTitleRequest {
+  titleKey: string;
+}
+
+// 대표 칭호 변경 응답 타입
+export interface UpdateRepresentTitleResponse {
+  success: boolean;
+  title?: Title;
+  message: string;
 } 


### PR DESCRIPTION
### 📌 작업 개요
- 이메일 로그인/회원가입, 마이페이지 유저정보 조회 및 수정, 칭호 목록 조회 및 수정 등 관련로직 추가

### ✅ 작업 내용
- 회원가입에서 마저 진행되지 않았던 부분 리팩토링 진행했고, 중복확인은 백엔드 api 연동이 필요합니다. (api가 준비가 안된 것 같음)
- 마이페이지의 칭호 목록 조회 및 저장(header 영역의 title과 연동)
- 그 외 mock api로 사용하던 부분들은 백엔드와 연동해두었고, 테스트 완료했습니다.