### PR TITLE
feat(timer): 집중/휴식 상태 토글 및 API 호출 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
         }
       />
       <Route
-        path='/studyroom/:id'
+        path="/studyroom/:roomId"
         element={
           <PrivateRoute>
             <StudyRoomPage />

--- a/src/pages/StudyRoomPage.tsx
+++ b/src/pages/StudyRoomPage.tsx
@@ -1,14 +1,13 @@
 import { LiveKitRoom, useRoomContext } from '@livekit/components-react';
-import api from '../lib/api/axios';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import Footer from '../components/common/Footer';
 import Header from '../components/common/Header';
 import MessageButton from '../components/MessageButton';
 import MessageModal from '../components/MessageModal';
 import VideoGrid from '../components/video/VideoGrid';
+import api from '../lib/api/axios';
 import { useAuthStore } from '../store/authStore';
-
 
 const StudyRoomPage = () => {
   const navigate = useNavigate();
@@ -16,7 +15,8 @@ const StudyRoomPage = () => {
   const [identity, setIdentity] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { user, token: accessToken } = useAuthStore();
-
+  const { roomId } = useParams<{ roomId: string }>();
+  const numericRoomId = Number(roomId);
 
   // 사용자 인증 정보가 없거나 토큰이 없는 경우 경고
   useEffect(() => {
@@ -129,7 +129,7 @@ const StudyRoomPage = () => {
         <main className="flex-1 w-full max-w-[1280px] mx-auto flex overflow-hidden">
 
           {/* 화상 공유 컴포넌트 */}
-          <VideoGrid />
+          <VideoGrid roomId={numericRoomId} />
 
           {/* 메시지 버튼 및 모달 */}
           <MessageButton onClick={() => setIsModalOpen(true)} />

--- a/src/store/focusStatusStore.ts
+++ b/src/store/focusStatusStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+export type FocusStatus = 'idle' | 'focus' | 'pause' | 'ended';
+
+export interface FocusStatusStore {
+  focusStatuses: Record<string, FocusStatus>; 
+  setStatus: (identity: string, status: FocusStatus) => void; 
+  resetAll: () => void; 
+}
+
+export const useFocusStatusStore = create<FocusStatusStore>((set) => ({
+  focusStatuses: {},
+
+  setStatus: (identity: string, status: FocusStatus) => {
+    set((state) => ({
+      focusStatuses: {
+        ...state.focusStatuses,
+        [identity]: status,
+      },
+    }));
+  },
+
+  resetAll: () => {
+    set({ focusStatuses: {} });
+  },
+}));


### PR DESCRIPTION
📌 작업 개요
LiveKit 기반 스터디룸에서 참여자의 집중/휴식 상태를 전환하고, 해당 상태를 서버에 API로 전송하는 기능 구현

✅ 작업 내용
VideoGrid 컴포넌트에 roomId 전달 로직 추가
사용자 상태(focus/pause) 토글 함수 toggleStatusColor() 구현
상태 변경 시 /api/timer/start 및 /api/timer/pause API 호출
요청 시 userId, roomId, Authorization 헤더 포함
LiveKit 참여자 트랙 기반 UI에 상태 표시 컬러 반영 (초록/빨강)