### PR TITLE
Feature/jiho oauth login

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,18 @@ VITE_USE_MOCK=false
 
 # 개발환경 구분
 VITE_NODE_ENV=development
+
+#
+// .env.local 또는 .env
+
+# Google OAuth
 VITE_GOOGLE_CLIENT_ID=52046583081-ihlomiiibi4iggbs6bkicd768mfkg2jq.apps.googleusercontent.com
+VITE_GOOGLE_REDIRECT_URI=VITE_API_BASE_URL/login/oauth2/code/google
+
+# Kakao OAuth
 VITE_KAKAO_CLIENT_ID=98521588a69d7a6c3945fb4307caebad
+VITE_KAKAO_REDIRECT_URI=https://api.live-study.com/login/oauth2/code/kakao
+
+# Naver OAuth
 VITE_NAVER_CLIENT_ID=bOs4Dsopdpf7V6UC3B6n
+VITE_NAVER_REDIRECT_URI=https://api.live-study.com/login/oauth2/code/naver

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import StudyRoomPage from './pages/StudyRoomPage';
 import TestPage from './pages/TestPage';
 import PrivateRoute from './routes/PrivateRoute';
 import { useAuthStore } from './store/authStore';
+import Redirection from './pages/Redirection';
+
 
 function App() {
   const initializeAuth = useAuthStore((state) => state.initializeAuth);
@@ -34,6 +36,7 @@ function App() {
       <Route path='/block-test-page' element={<BlockTestPage />} />
       <Route path='/chat-test' element={<ChatTestPage />} />
       <Route path='*' element={<NotFoundPage />} />
+      <Route path="/kakao/callback" element={<Redirection />} />
 
       {/* 보호 라우트 */}
       <Route
@@ -52,6 +55,7 @@ function App() {
           </PrivateRoute>
         }
       />
+      
       <Route
         path='/mypage'
         element={

--- a/src/lib/constants/authUrls.ts
+++ b/src/lib/constants/authUrls.ts
@@ -1,30 +1,5 @@
-const VITE_API_BASE_URL = import.meta.env.VITE_API_BASE_URL!;
+export const GOOGLE_AUTH_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${import.meta.env.VITE_GOOGLE_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_GOOGLE_REDIRECT_URI}&response_type=code&scope=profile email`;
 
-export const GOOGLE_AUTH_URL =
-  'https://accounts.google.com/o/oauth2/v2/auth?' +
-  new URLSearchParams({
-    client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID!,
-    redirect_uri: `${VITE_API_BASE_URL}/login/oauth2/code/google`,
-    response_type: 'code',
-    scope: 'openid profile email',
-    access_type: 'offline',
-    prompt: 'consent',
-  });
+export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${import.meta.env.VITE_KAKAO_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_KAKAO_REDIRECT_URI}&response_type=code`;
 
-
-export const KAKAO_AUTH_URL =
-  'https://kauth.kakao.com/oauth/authorize?' +
-  new URLSearchParams({
-    client_id: import.meta.env.VITE_KAKAO_CLIENT_ID!,
-    redirect_uri: `${VITE_API_BASE_URL}/login/oauth2/code/kakao`,
-    response_type: 'code',
-  });
-
-export const NAVER_AUTH_URL =
-  'https://nid.naver.com/oauth2.0/authorize?' +
-  new URLSearchParams({
-    client_id: import.meta.env.VITE_NAVER_CLIENT_ID!,
-    redirect_uri: `${VITE_API_BASE_URL}/login/oauth2/code/naver`,
-    response_type: 'code',
-    state: 'liveStudyStateToken',
-  });
+export const NAVER_AUTH_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${import.meta.env.VITE_NAVER_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_NAVER_REDIRECT_URI}&state=STATE_STRING`;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -22,24 +22,16 @@ export default function LoginPage() {
             <Link to={'/email-login'}>Email 로그인</Link>
           </button>
            
-          <a
-            href={GOOGLE_AUTH_URL}
-            className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200 text-center"
-          >
+          
+          <a href={GOOGLE_AUTH_URL} className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200 text-center">
             Google 로그인
           </a>
 
-          <a
-            href={KAKAO_AUTH_URL}
-            className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200 text-center"
-          >
+          <a href={KAKAO_AUTH_URL} className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200 text-center">
             Kakao 로그인
           </a>
 
-          <a
-            href={NAVER_AUTH_URL}
-            className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200 text-center"
-          >
+          <a href={NAVER_AUTH_URL} className="w-full py-3 bg-gray-100 border border-gray-300 rounded-xl text-body1_R text-gray-500 hover:bg-gray-200 text-center">
             Naver 로그인
           </a>
         </div>

--- a/src/pages/Redirection.tsx
+++ b/src/pages/Redirection.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+
+export default function Redirection() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const code = searchParams.get("code");
+    const state = searchParams.get("state");
+    const pathname = location.pathname;
+
+    const provider = pathname.includes("google")
+      ? "google"
+      : pathname.includes("kakao")
+      ? "kakao"
+      : "naver";
+
+    if (code) {
+      fetch(`/api/oauth/${provider}/callback?code=${code}${state ? `&state=${state}` : ''}`)
+        .then((res) => res.json())
+        .then((data) => {
+          navigate("/main");
+        });
+    }
+  }, [location]);
+
+  return <div>로그인 처리 중...</div>;
+}

--- a/src/pages/StudyRoomPage.tsx
+++ b/src/pages/StudyRoomPage.tsx
@@ -8,6 +8,7 @@ import MessageModal from '../components/MessageModal';
 import VideoGrid from '../components/video/VideoGrid';
 import api from '../lib/api/axios';
 import { useAuthStore } from '../store/authStore';
+import { Track, TrackPublication, Participant } from 'livekit-client';
 
 const StudyRoomPage = () => {
   const navigate = useNavigate();
@@ -33,8 +34,8 @@ const StudyRoomPage = () => {
         const res = await api.post(
           '/api/livekit/token',
           {
-            roomName: 'studyroom',
-            identity: generatedIdentity,
+            roomName: roomId,
+            identity: user.uid,
           },
           {
             headers: {
@@ -43,34 +44,64 @@ const StudyRoomPage = () => {
           }
         );
         setToken(res.data.token);
+    console.log('[🔑 토큰]', res.data.token);
+
       } catch (err) {
         console.error('토큰 생성 실패:', err);
       }
     };
 
     fetchToken();
+    
   }, [user, accessToken]);
 
 
   // 디버깅 용 나중에 삭제 예정
-  const RoomLogger = () => {
-    const room = useRoomContext();
+ const RoomLogger = () => {
+  const room = useRoomContext();
 
-    useEffect(() => {
-      if (room.state === 'connected') {
-        const local = room.localParticipant;
-        const videoTrack = local
-          .getTrackPublications()
-          .find((pub) => pub.track?.kind === 'video')?.track;
+  useEffect(() => {
+    console.log('[🧩 ROOM STATE]', room.state);
 
-        if (!videoTrack) {
-          console.warn('비디오 트랙이 없습니다.');
-        }
-      }
-    }, [room]);
+    const handleConnected = () => {
+      console.log('✅ LiveKit 연결 성공');
+    };
 
-    return null;
-  };
+    const handleDisconnected = () => {
+      console.warn('❌ LiveKit 연결 종료됨');
+    };
+
+    const handleTrackSubscribed = (
+      track: Track,
+      publication: TrackPublication,
+      participant: Participant
+    ) => {
+      console.log(`🎥 ${participant.identity}의 ${track.kind} 트랙 구독됨`);
+    };
+
+    const handleTrackUnsubscribed = (
+      track: Track,
+      publication: TrackPublication,
+      participant: Participant
+    ) => {
+      console.log(`🛑 ${participant.identity}의 ${track.kind} 트랙 해제됨`);
+    };
+
+    room.on('connected', handleConnected);
+    room.on('disconnected', handleDisconnected);
+    room.on('trackSubscribed', handleTrackSubscribed);
+    room.on('trackUnsubscribed', handleTrackUnsubscribed);
+
+    return () => {
+      room.off('connected', handleConnected);
+      room.off('disconnected', handleDisconnected);
+      room.off('trackSubscribed', handleTrackSubscribed);
+      room.off('trackUnsubscribed', handleTrackUnsubscribed);
+    };
+  }, [room]);
+
+  return null;
+};
 
 
   // 스터디룸 퇴장 처리
@@ -104,7 +135,7 @@ const StudyRoomPage = () => {
   return (
     <LiveKitRoom
       token={token}
-      serverUrl="wss://livestudy-7t5xkn6m.livekit.cloud"
+      serverUrl="wss://api.live-study.com/ws"
       connect
       video
       audio={false} 

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -18,6 +18,7 @@ interface AuthState {
     };
   } | null;
   token: string | null;
+  setToken: (token: string) => void;
 
   titleList?: {
     key: string;
@@ -53,14 +54,19 @@ export const useAuthStore = create<AuthState>()(
   persist<AuthState>(
     (set, get) => ({
       isLoggedIn: false,
-        user: {
-    uid: '',
-    email: '',
-    nickname: '',
-    profileImageUrl: '',
-  },
+      user: {
+        uid: '',
+        email: '',
+        nickname: '',
+        profileImageUrl: '',
+      },
       token: null,
       titleList: [],
+
+      setToken: (token) => {
+        set({ token });
+        setAuthToken(token);
+      },
 
       updateUser: (updates) =>
         set((state) => ({
@@ -73,21 +79,9 @@ export const useAuthStore = create<AuthState>()(
             : null,
         })),
 
-        login: (
-    { uid, email, nickname, profileImageUrl, title }: {
-      uid: string;
-      email: string;
-      nickname: string;
-      profileImageUrl?: string;
-          title?: {
-            key: string;
-            name: string;
-            description: string;
-            icon: string;
-            isRepresent: boolean;
-          };
-        },
-        token: string
+      login: (
+        { uid, email, nickname, profileImageUrl, title },
+        token
       ) => {
         const defaultTitle = {
           key: "no-title",
@@ -97,19 +91,21 @@ export const useAuthStore = create<AuthState>()(
           isRepresent: true,
         };
 
-            set({
-      user: {
-        uid,
-        email,
-        nickname,
-        profileImageUrl,
-        title: title || defaultTitle,
-      },
+        set({
+          user: {
+            uid,
+            email,
+            nickname,
+            profileImageUrl,
+            title: title || defaultTitle,
+          },
           token,
           isLoggedIn: true,
         });
+        setAuthToken(token);
       },
-      logout: () => 
+
+      logout: () =>
         set({ isLoggedIn: false, user: null, token: null }),
 
       fetchTitleList: async () => {
@@ -118,7 +114,6 @@ export const useAuthStore = create<AuthState>()(
         set({ titleList: data });
       },
 
-      // 토큰 자동 복원 함수
       initializeAuth: () => {
         const state = get();
         if (state.token && state.isLoggedIn) {
@@ -130,4 +125,4 @@ export const useAuthStore = create<AuthState>()(
       name: "live-study-auth-storage",
     }
   )
-)
+);


### PR DESCRIPTION
📌 작업 개요
LiveStudy 프로젝트에 Kakao, Google, Naver OAuth 로그인을 적용하고, 로그인 후 토큰 저장 및 상태 복원까지 연동하는 작업을 진행했습니다.

✅ 작업 내용
환경 변수 설정 (.env)
 - VITE_API_BASE_URL 및 각 OAuth 리디렉션 URI, Client ID 설정

OAuth URL 분리 (authUrls.ts)
 - Kakao, Google, Naver 인증 URL을 .env 기반으로 설정

인증 상태 전역 관리 (authStore.ts)
 - setToken() 메서드 추가
 - 로그인 후 setAuthToken() 자동 적용
 - 초기 상태 복원 시 토큰 자동 설정 (initializeAuth())

로그인 페이지 (LoginPage.tsx)
 - 각 로그인 버튼 클릭 시 외부 인증 URL로 이동하도록 연결
 - 리디렉션 처리 (Redirection.tsx)
 - OAuth 인증 후 전달된 토큰과 유저 정보를 Zustand로 저장
 - 로그인 상태 활성화 처리

라우팅 설정 (App.tsx)
 - /kakao/callback 경로에 대한 <Redirection /> 컴포넌트 매핑

스터디룸 진입 (StudyRoomPage.tsx)
 - 인증된 사용자만 진입 가능하도록 로직 개선