### PR TITLE
fix: header 영역 프로필과 통계 연동 및 마이페이지 통계 api 일부 조정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -98,7 +98,14 @@ const Header = () => {
             </div>
           )}
           <div className="relative z-50" ref={menuRef}>
-            { isLoggedIn && <div onClick={toggleMenu} className="w-10 h-10 rounded-full bg-gray-300 cursor-pointer" />}
+            { isLoggedIn && (
+              <img 
+                onClick={toggleMenu} 
+                src={user?.profileImageUrl || "/img/my-page-profile-image-1.jpg"} 
+                alt={`${user?.nickname}님의 프로필`}
+                className="w-10 h-10 rounded-full bg-gray-300 cursor-pointer object-cover"
+              />
+            )}
             { menuOpen && (
               <div className="absolute right-0 mt-2 w-32 bg-white border rounded-md shadow-md text-sm z-10">
                 <ul className="divide-y divide-gray-200">

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -14,9 +14,7 @@
 
 import axios from 'axios';
 import type {
-  AverageFocusRatioApiResponse,
   ConnectionTestResult,
-  DailyFocusApiResponse,
   GrantTitleRequest,
   GrantTitleResponse,
   LoginData,
@@ -425,37 +423,7 @@ export async function getUserStats(): Promise<StatsApiResponse> {
   }
 }
 
-// 일별 집중도 추이 조회
-export async function getDailyFocus(startDate?: string, endDate?: string): Promise<DailyFocusApiResponse> {
-  try {
-    const params = new URLSearchParams();
-    if (startDate) params.append('startDate', startDate);
-    if (endDate) params.append('endDate', endDate);
-    
-    const response = await api.get(`/api/user/stat/daily-focus?${params.toString()}`);
-    
-    return { success: true, data: response.data };
-  } catch (error: unknown) {
-    handleAxiosError(error, '일별 집중도 조회에 실패했습니다.');
-    throw error;
-  }
-}
 
-// 평균 집중률 조회
-export async function getAverageFocusRatio(startDate?: string, endDate?: string): Promise<AverageFocusRatioApiResponse> {
-  try {
-    const params = new URLSearchParams();
-    if (startDate) params.append('startDate', startDate);
-    if (endDate) params.append('endDate', endDate);
-    
-    const response = await api.get(`/api/user/stat/average-focus-ratio?${params.toString()}`);
-    
-    return { success: true, data: response.data };
-  } catch (error: unknown) {
-    handleAxiosError(error, '평균 집중률 조회에 실패했습니다.');
-    throw error;
-  }
-}
 
 // 칭호 목록 조회 (OpenAPI 실제 엔드포인트 사용)
 export async function getUserTitles(userId?: number): Promise<TitlesApiResponse> {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -398,57 +398,7 @@ export const handlers = [
     );
   }),
 
-  // 일별 집중도 추이 조회 API
-  rest.get('/api/user/stat/daily-focus', (req, res, ctx) => {
-    const url = new URL(req.url.toString());
-    const startDate = url.searchParams.get('startDate') || '2025-08-01';
-    const endDate = url.searchParams.get('endDate') || '2025-08-03';
 
-    // startDate와 endDate를 활용한 데이터 생성 (현재는 고정값 반환)
-    console.log(`집중도 조회 기간: ${startDate} ~ ${endDate}`);
-
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          recordDate: '2025-08-01',
-          dailyStudyTime: 3600,
-          dailyAwayTime: 300,
-          focusRatio: 0.92
-        },
-        {
-          recordDate: '2025-08-02',
-          dailyStudyTime: 4200,
-          dailyAwayTime: 600,
-          focusRatio: 0.87
-        },
-        {
-          recordDate: '2025-08-03',
-          dailyStudyTime: 3000,
-          dailyAwayTime: 900,
-          focusRatio: 0.77
-        }
-      ])
-    );
-  }),
-
-  // 평균 집중률 조회 API
-  rest.get('/api/user/stat/average-focus-ratio', (req, res, ctx) => {
-    const url = new URL(req.url.toString());
-    const startDate = url.searchParams.get('startDate') || '2025-08-01';
-    const endDate = url.searchParams.get('endDate') || '2025-08-07';
-
-    console.log(`평균 집중률 조회 기간: ${startDate} ~ ${endDate}`);
-
-    return res(
-      ctx.status(200),
-      ctx.json({
-        startDate,
-        endDate,
-        averageFocusRatio: 0.85
-      })
-    );
-  }),
 
   // 칭호 목록 조회 API (새로운 형식)
   rest.get('/api/titles/:userId/list', (req, res, ctx) => {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -98,20 +98,7 @@ export interface TodayStudyTimeResponse {
   todayStudyTime: number;
 }
 
-// 일별 기록 응답 타입
-export interface DailyRecordResponse {
-  recordDate: string;
-  dailyStudyTime: number;
-  dailyAwayTime: number;
-  focusRatio: number;
-}
 
-// 평균 집중률 응답 타입
-export interface AverageFocusRatioResponse {
-  startDate: string;
-  endDate: string;
-  averageFocusRatio: number;
-}
 
 // 마이페이지 수정 요청 타입
 export interface UpdateNicknameRequest {
@@ -154,17 +141,7 @@ export interface TodayStudyTimeApiResponse {
   data: TodayStudyTimeResponse;
 }
 
-// 일별 집중도 API 응답 타입
-export interface DailyFocusApiResponse {
-  success: boolean;
-  data: DailyRecordResponse[];
-}
 
-// 평균 집중률 API 응답 타입
-export interface AverageFocusRatioApiResponse {
-  success: boolean;
-  data: AverageFocusRatioResponse;
-}
 
 // 수정 API 응답 타입
 export interface UpdateApiResponse {


### PR DESCRIPTION
### 📌 작업 개요
- ex) 로그인 UI 구현 및 상태관리 연동

### ✅ 작업 내용
1. 📈 통계 API 정리 및 최적화
- 불필요한 API 제거: daily-focus, average-focus-ratio 관련 코드 삭제
- 핵심 통계만 유지: /api/user/stat/normal, /api/user/stat/today-study-time
- 타입 정의 정리: 사용하지 않는 인터페이스 및 타입 제거
- Mock handlers 정리: 불필요한 Mock API 엔드포인트 삭제

2. 🏠 마이페이지 통계 기능 강화
- 금일 집중시간 추가: 실시간 업데이트되는 오늘 집중시간 표시
- 통계 로딩 상태 개선: 개별 로딩 상태 관리로 UX 향상
- 에러 처리 강화: try-catch 구문 추가 및 기본값 제공
- 데이터 표시 순서: 금일 → 누적 집중시간 → 누적 출석일 → 연속 출석일

3. 🖼️ Header-MyPage 연동 시스템
- 프로필 이미지 동기화: 마이페이지 변경 시 Header에 즉시 반영
- 실시간 통계 표시: Header의 "오늘 집중 시간" 1분마다 자동 업데이트
- authStore 활용: 전역 상태 관리로 일관성 보장