### PR TITLE
Fix/jinwon mypage api

### DIFF
--- a/src/lib/api/axios.ts
+++ b/src/lib/api/axios.ts
@@ -26,7 +26,8 @@ api.interceptors.request.use(
       '/api/user/profile/nickname',
       '/api/user/profile/email',
       '/api/user/profile/password',
-      '/api/user/profile/profileImage'
+      '/api/user/profile/profileImage',
+      '/api/images/upload'
     ];
     
     // 현재 요청 URL이 인증이 필요한 API인지 확인
@@ -39,7 +40,7 @@ api.interceptors.request.use(
       const token = localStorage.getItem('authToken');
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;
-        console.log('�� 인증 토큰 추가:', config.url);
+        console.log('🔑 인증 토큰 추가:', config.url);
       } else {
         console.warn('⚠️ 토큰이 없습니다:', config.url);
       }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -116,9 +116,12 @@ useEffect(() => {
           description: title.description,
           acquiredAt: "2024-01-01",
           icon: "🏆",
-          isRepresent: title.isRepresentative
+          isRepresent: title.isRepresentative ?? title.representative ?? false
         }));
         setTitles(convertedTitles);
+        // 대표 칭호를 기본 선택값으로 반영
+        const currentRepresent = titlesResult.data.find(t => t.isRepresentative || t.representative);
+        if (currentRepresent) setSelectedTitle(String(currentRepresent.titleId));
       } else {
         console.warn("칭호 목록 조회 실패");
         // 기본 칭호 데이터 설정

--- a/src/pages/Redirection.tsx
+++ b/src/pages/Redirection.tsx
@@ -1,5 +1,8 @@
 import { useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { getUserProfile } from "../lib/api/auth";
+import { setAuthToken } from "../lib/api/token";
+import { useAuthStore } from "../store/authStore";
 
 export default function Redirection() {
   const navigate = useNavigate();
@@ -18,11 +21,38 @@ export default function Redirection() {
       : "naver";
 
     if (code) {
-      fetch(`/api/oauth/${provider}/callback?code=${code}${state ? `&state=${state}` : ''}`)
-        .then((res) => res.json())
-        .then((data) => {
+      (async () => {
+        try {
+          const res = await fetch(`/api/oauth/${provider}/callback?code=${code}${state ? `&state=${state}` : ''}`);
+          const data = await res.json();
+          const token = data?.token as string | undefined;
+          if (token) {
+            // 토큰 저장 (axios 기본헤더 + localStorage)
+            setAuthToken(token);
+            // 프로필 동기화 및 스토어 로그인 처리
+            try {
+              const profile = await getUserProfile();
+              if (profile.success && profile.data) {
+                const { email, nickname, profileImage } = profile.data;
+                const login = useAuthStore.getState().login;
+                login(
+                  {
+                    uid: email.split('@')[0],
+                    email,
+                    nickname,
+                    profileImageUrl: profileImage || 'default.jpg',
+                  },
+                  token
+                );
+              }
+            } catch {}
+          }
           navigate("/main");
-        });
+        } catch (e) {
+          console.error('소셜 로그인 콜백 처리 실패', e);
+          navigate('/login');
+        }
+      })();
     }
   }, [location]);
 

--- a/src/pages/Redirection.tsx
+++ b/src/pages/Redirection.tsx
@@ -1,8 +1,5 @@
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { getUserProfile } from "../lib/api/auth";
-import { setAuthToken } from "../lib/api/token";
-import { useAuthStore } from "../store/authStore";
 
 export default function Redirection() {
   const navigate = useNavigate();
@@ -21,38 +18,11 @@ export default function Redirection() {
       : "naver";
 
     if (code) {
-      (async () => {
-        try {
-          const res = await fetch(`/api/oauth/${provider}/callback?code=${code}${state ? `&state=${state}` : ''}`);
-          const data = await res.json();
-          const token = data?.token as string | undefined;
-          if (token) {
-            // 토큰 저장 (axios 기본헤더 + localStorage)
-            setAuthToken(token);
-            // 프로필 동기화 및 스토어 로그인 처리
-            try {
-              const profile = await getUserProfile();
-              if (profile.success && profile.data) {
-                const { email, nickname, profileImage } = profile.data;
-                const login = useAuthStore.getState().login;
-                login(
-                  {
-                    uid: email.split('@')[0],
-                    email,
-                    nickname,
-                    profileImageUrl: profileImage || 'default.jpg',
-                  },
-                  token
-                );
-              }
-            } catch {}
-          }
+      fetch(`/api/oauth/${provider}/callback?code=${code}${state ? `&state=${state}` : ''}`)
+        .then((res) => res.json())
+        .then((data) => {
           navigate("/main");
-        } catch (e) {
-          console.error('소셜 로그인 콜백 처리 실패', e);
-          navigate('/login');
-        }
-      })();
+        });
     }
   }, [location]);
 


### PR DESCRIPTION
### 📌 작업 개요
- 인증 토큰 주입/저장 로직 통일 및 마이페이지 401 에러 해결
- 닉네임/칭호 동기화 로직 개선으로 헤더/마이페이지 표시 일관성 확보

### ✅ 작업 내용

1. 공통 토큰 처리
- setAuthToken 단일 모듈로 통일(src/lib/api/token.ts) 및 중복 구현 제거
- 로그인 성공 시 토큰을 axios 기본 헤더 + localStorage('authToken')에 저장
2. axios 인터셉터 개선
- 인증 필요 경로에 /api/images/upload 추가 → 이미지 업로드 시 401 방지
- 인증 토큰 로그 출력 정리
3. 프로필/스토어 동기화
- getUserProfile() 성공 시 useAuthStore.updateUser로 email/nickname/profileImageUrl 즉시 반영
4. 칭호 API의 userId 하드코딩 제거
- JWT 페이로드의 userId(또는 id) 파싱하여 사용, 실패 시 스토어 uid 숫자화로 대체
- 대표 칭호 변경 시 스토어의 user.title 동기화
5. 마이페이지 UI/데이터 처리
- 칭호 목록의 대표 칭호 필드(isRepresentative/representative) 모두 대응
- 대표 칭호 자동 선택 반영(드롭다운 기본값 설정)