### PR TITLE
fix: stat 무한 재호출/리랜더 홀드

### DIFF
--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -151,7 +151,7 @@ useEffect(() => {
   };
   
   fetchUserData();
-}, [user]);
+}, []);
 
 // 금일 집중시간 실시간 업데이트 (1분마다)
 useEffect(() => {


### PR DESCRIPTION
### 📌 작업 개요
- 마이페이지의 하단 통계영역 무한 재호출/리랜더 홀드

### ✅ 작업 내용
- 통계 영역 깜빡임의 원인: getUserProfile()가 스토어를 업데이트 → user가 변함 → useEffect가 user에 의존해 재실행 → 반복 호출/리렌더 루프.
- 조치: MyPage의 데이터 로딩 useEffect를 1회만 실행되도록 의존성 배열을 빈 배열로 변경했습니다. 이로써 루프/깜빡임이 중단됩니다.