### PR TITLE
fix(profile-image): normalize relative image URLs to absolute using V…

### DIFF
--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -15,6 +15,7 @@ import {
   uploadProfileImage
 } from "../lib/api/auth";
 import { useAuthStore } from "../store/authStore";
+import { normalizeImageUrl } from "../utils/image";
 
 export default function MyPage() {
   const { user } = useAuthStore();
@@ -42,7 +43,7 @@ useEffect(() => {
       const profileResult = await getUserProfile();
       if (profileResult.success && profileResult.data) {
         const profile = profileResult.data;
-        setProfileImage(profile.profileImage || "/img/my-page-profile-image-1.jpg");
+        setProfileImage(normalizeImageUrl(profile.profileImage) || "/img/my-page-profile-image-1.jpg");
         setNickname(profile.nickname || "");
         setEmail(profile.email || "");
         setSelectedTitle(profile.selectedTitle || "");
@@ -50,7 +51,7 @@ useEffect(() => {
         console.warn("프로필 정보 조회 실패");
         // authStore에서 기본 정보 사용
         if (user) {
-          setProfileImage(user.profileImageUrl || "/img/my-page-profile-image-1.jpg");
+          setProfileImage(normalizeImageUrl(user.profileImageUrl) || "/img/my-page-profile-image-1.jpg");
           setNickname(user.nickname || "");
           setEmail(user.email || "");
         }
@@ -134,7 +135,7 @@ useEffect(() => {
       console.error("사용자 데이터 조회 실패:", error);
       // 에러 시 기본 데이터 사용
       if (user) {
-        setProfileImage(user.profileImageUrl || "/img/my-page-profile-image-1.jpg");
+        setProfileImage(normalizeImageUrl(user.profileImageUrl) || "/img/my-page-profile-image-1.jpg");
         setNickname(user.nickname || "");
         setEmail(user.email || "");
       }
@@ -190,8 +191,8 @@ useEffect(() => {
         // 업로드된 이미지 URL로 프로필 이미지 업데이트
         const updateResult = await updateProfileImage(uploadResult.imageUrl);
         
-        if (updateResult.success) {
-          setProfileImage(uploadResult.imageUrl);
+          if (updateResult.success) {
+          setProfileImage(normalizeImageUrl(uploadResult.imageUrl) || "/img/my-page-profile-image-1.jpg");
           alert("프로필 이미지가 성공적으로 변경되었습니다.");
         } else {
           alert(updateResult.message || "프로필 이미지 업데이트에 실패했습니다.");

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,21 @@
+export function normalizeImageUrl(url: string | undefined | null): string | undefined {
+  if (!url) return url ?? undefined;
+  const value = String(url);
+  if (/^https?:\/\//i.test(value)) return value;
+  const base = (import.meta as any)?.env?.VITE_API_BASE_URL || 'https://api.live-study.com';
+  if (value.startsWith('/')) return `${base}${value}`;
+  return `${base}/${value}`;
+}
+
+export function pickImageUrlFromResponse(data: unknown): string | undefined {
+  // 서버가 문자열 혹은 객체로 반환할 수 있어 유연하게 파싱
+  if (typeof data === 'string') return data;
+  if (data && typeof data === 'object') {
+    const anyData = data as Record<string, unknown>;
+    // 우선순위: profileImage → imageUrl → url
+    const candidate = (anyData.profileImage || anyData.imageUrl || anyData.url) as string | undefined;
+    if (candidate) return candidate;
+  }
+  return undefined;
+}
+


### PR DESCRIPTION
📌 작업 개요
- 프로필 이미지 경로 정규화(상대 경로 → 절대 URL)로 이미지 미표시 이슈 해결

✅ 작업 내용
유틸 추가: normalizeImageUrl, pickImageUrlFromResponse (src/utils/image.ts)

프로필 연동부 정규화 적용
- getUserProfile(): 응답의 profileImage를 절대 URL로 변환 후 스토어 반영
- uploadProfileImage(): 응답에서 이미지 URL 추출/정규화
- updateProfileImage(): 응답에서 최종 이미지 URL 추출/정규화 후 스토어 반영

마이페이지 표시 정규화 적용
- 초기 로딩/스토어 fallback/업로드 완료 후 로컬 상태에 절대 URL 적용