### PR TITLE
fix: 프로필 이미지 경로 절대 URL 정규화 및 업로드/저장 응답 파싱 보강

### DIFF
--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -37,9 +37,9 @@ import type {
   UserActivity,
   UserStudyStat
 } from '../../types/auth';
+import { normalizeImageUrl, pickImageUrlFromResponse } from '../../utils/image';
 import api from './axios';
 import { setAuthToken as setAuthTokenGlobal } from './token';
-import { normalizeImageUrl, pickImageUrlFromResponse } from '../../utils/image';
 
 // ============================================
 // 에러 처리 및 유틸리티 함수들


### PR DESCRIPTION
### 📌 작업 개요
- 상대 경로(/images/...) 응답으로 인한 이미지 미표시 이슈 해결

### ✅ 작업 내용
- 유틸 추가: normalizeImageUrl, pickImageUrlFromResponse
- getUserProfile에서 profileImage를 절대 URL로 정규화 후 스토어 반영
- uploadProfileImage/updateProfileImage 응답에서 이미지 URL 안전 파싱 및 정규화
- MyPage 렌더링/업로드 후 상태에도 정규화 적용
