### PR TITLE
feat(auth): AuthSuccessPage에서 api 인스턴스로 프로필 조회 및 로그인 상태 반영

### DIFF
--- a/src/pages/AuthSuccessPage.tsx
+++ b/src/pages/AuthSuccessPage.tsx
@@ -2,28 +2,62 @@ import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { setAuthToken } from "../lib/api/token";
 import { useAuthStore } from "../store/authStore";
+import api from '../lib/api/axios';
 
 export default function AuthSuccessPage() {
   const nav = useNavigate();
   const { search, hash } = useLocation();
-  const login = useAuthStore((state) => state.login);
+  const login = useAuthStore((s) => s.login);
 
   useEffect(() => {
-    const qs = search && search !== "" ? search : hash?.replace(/^#/, "") || "";
-    const params = new URLSearchParams(qs.startsWith("?") ? qs : `?${qs}`);
-    const token = params.get("token");
-    const isNew = params.get("isNew") === "true";
+    const run = async () => {
+      const qs = search && search !== "" ? search : hash?.replace(/^#/, "") || "";
+      const params = new URLSearchParams(qs.startsWith("?") ? qs : `?${qs}`);
+      const token = params.get("token");
+      const isNew = params.get("isNew") === "true";
 
-    if (!token) {
-      nav("/auth/failure?error=missing_token", { replace: true });
-      return;
-    }
+      if (!token) {
+        nav("/auth/failure?error=missing_token", { replace: true });
+        return;
+      }
 
-    setAuthToken(token);
+      // 토큰 저장 + api 기본 Authorization 헤더 설정
+      setAuthToken(token);
 
-    window.history.replaceState(null, "", "/auth/success");
+      // 환경에서 프로필 호출 체크 
+      if (import.meta.env.DEV) {
+        try {
+          const res = await api.get("/api/user/profile");
+          console.log("[auth] profile status:", res.status);
+        } catch (e) {
+          console.warn("[auth] profile check failed:", e);
+        }
+      }
 
-    nav(isNew ? "/signup/extra-info" : "/", { replace: true });
+      // 실제 프로필 조회
+      try {
+        const res = await api.get("/api/user/profile");
+        const p = res?.data;
+        login(
+          {
+            uid: p?.email?.split("@")[0] ?? p?.nickname ?? "user",
+            email: p?.email ?? "",
+            nickname: p?.nickname ?? "",
+            profileImageUrl: p?.profileImage ?? "default.jpg",
+          },
+          token
+        );
+      } catch {
+        // 실패 시 기본값으로 로그인 처리
+        login({ uid: "user", email: "", nickname: "", profileImageUrl: "default.jpg" }, token);
+      } finally {
+        // 쿼리스트링 정리 후 라우팅
+        window.history.replaceState(null, "", "/auth/success");
+        nav(isNew ? "/signup/extra-info" : "/", { replace: true });
+      }
+    };
+
+    void run();
   }, [search, hash, nav, login]);
 
   return <div>로그인 처리 중입니다…</div>;


### PR DESCRIPTION
📌 작업 개요
AuthSuccessPage의 인증 후 처리 흐름을 axios api 인스턴스로 일원화하고, 프로필 조회 → 전역 스토어 로그인 → 라우팅까지 안정화했습니다. 토큰 저장 이후 모든 요청이 Authorization: Bearer 헤더를 자동 사용하도록 정리했습니다.

✅ 작업 내용
토큰 저장 → Authorization 헤더 자동 적용(setAuthToken(token))
실제 프로필 조회: api.get("/api/user/profile")
응답으로 useAuthStore.login 설정(uid/email/nickname/profileImageUrl)
실패 시 기본 프로필로 폴백 로그인
URL 정리: window.history.replaceState(null, "", "/auth/success")
라우팅 분기: isNew ? "/signup/extra-info" : "/"
