### PR TITLE
Feature/timer video refactor

### DIFF
--- a/src/components/video/VideoGrid.tsx
+++ b/src/components/video/VideoGrid.tsx
@@ -2,12 +2,11 @@ import { useTracks } from '@livekit/components-react';
 import { isAxiosError } from 'axios';
 import { LocalParticipant, Participant, RemoteParticipant, Track } from 'livekit-client';
 import { useMemo, useState } from 'react';
-import { MdReport, MdVisibility, MdVisibilityOff } from 'react-icons/md';
 import api from '../../lib/api/axios';
 import { useAuthStore } from '../../store/authStore';
 import type { FocusStatus } from '../../store/focusStatusStore';
 import { useFocusStatusStore } from '../../store/focusStatusStore';
-import LiveVideoBox from './LiveVideoBox';
+import VideoParticipant from './VideoParticipant';
 import VideoReportModal from './VideoReportModal';
 
 type ReportReason = '욕설' | '음란' | '방해' | '기타';
@@ -205,9 +204,8 @@ const VideoGrid = ({ roomId }: { roomId: number }) => {
     return `p-${idx}`;
   };
 
-  return (
+    return (
     <>
-      {/* 신고 모달: 표시용 이름만 노출 */}
       <VideoReportModal
         targetName={reportInfo?.name ?? ''}
         selected={selectedReason}
@@ -226,83 +224,23 @@ const VideoGrid = ({ roomId }: { roomId: number }) => {
           const targetName = makeTargetName(participant);
           const isPlaceholder = displayName === '연결 중…';
 
-          const dotColor =
-            focusStatuses[key] === 'focus'
-              ? 'bg-green-500'
-              : focusStatuses[key] === 'pause'
-              ? 'bg-red-500'
-              : 'bg-gray-400'; // idle
-
           return (
-            <div
+            <VideoParticipant
               key={`${key}-${idx}`}
-              className="bg-gray-100 rounded shadow-sm overflow-hidden flex items-center justify-center aspect-[4/3] relative"
-            >
-              <div className="w-full h-full bg-gray-200 rounded-md relative">
-                {/* 상태 점 */}
-                <div
-                  onClick={() => {
-                    if (isPlaceholder) return;
-                    if (!(participant instanceof LocalParticipant) && !participant.isLocal) return; // 로컬만 허용
-                    toggleStatusColor(key);
-                  }}
-                  className={`absolute top-1 left-1 w-2 h-2 rounded-full z-50 ${
-                    isPlaceholder ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'
-                  } ${dotColor}`}
-                />
-
-                {/* 타이머 */}
-                <div className="absolute top-1 right-1 flex justify-center items-center gap-[0.2rem] mt-[0.1rem]">
-                  <span className="text-caption2_M text-white bg-black/50 px-1 rounded">01:59:59</span>
-                </div>
-
-                {/* 영상 */}
-                {hiddenParticipants[key] ? (
-                  <div className="flex items-center justify-center w-full h-full bg-gray-300 text-sm text-gray-600 text-center px-2">
-                    <p>
-                      <span className="font-semibold text-black">{displayName}</span>님의 화면은 현재 가려졌습니다.
-                    </p>
-                  </div>
-                ) : (
-                  <LiveVideoBox participant={participant} />
-                )}
-
-                {/* 하단 바 */}
-                <div className="absolute bottom-0 left-0 w-full px-2 py-1 bg-black/40 text-white text-xs flex items-center justify-center">
-                  <button
-                    disabled={isPlaceholder}
-                    className={`absolute right-8 ${
-                      isPlaceholder ? 'opacity-40 cursor-not-allowed' : 'text-gray-300 hover:text-gray-500'
-                    }`}
-                    onClick={() => !isPlaceholder && toggleHide(key)}
-                  >
-                    {hiddenParticipants[key] ? <MdVisibility size={16} /> : <MdVisibilityOff size={16} />}
-                  </button>
-
-                  <div className="flex items-center space-x-1">
-                    <span className="text-sm">
-                      {participant instanceof LocalParticipant || participant.isLocal ? titleIcon : '🌱'}
-                    </span>
-                    <span className="text-caption1_M text-lime-400 font-semibold">
-                      {participant instanceof LocalParticipant || participant.isLocal ? titleName : '칭호'}
-                    </span>
-                    <span className="text-caption1_M font-semibold">{displayName}</span>
-                  </div>
-
-                  {/* 신고 버튼 */}
-                  <button
-                    disabled={isPlaceholder}
-                    className={`absolute right-2 ${
-                      isPlaceholder ? 'opacity-40 cursor-not-allowed' : 'text-red-300 hover:text-red-500'
-                    }`}
-                    onClick={() => !isPlaceholder && openReport(key, targetName)}
-                    aria-label="신고하기"
-                  >
-                    <MdReport size={16} />
-                  </button>
-                </div>
-              </div>
-            </div>
+              participant={participant}
+              identityKey={key}
+              idx={idx}
+              displayName={displayName}
+              targetName={targetName}
+              isPlaceholder={isPlaceholder}
+              hidden={hiddenParticipants[key] ?? false}
+              focusStatus={focusStatuses[key] ?? 'idle'}
+              titleIcon={titleIcon}
+              titleName={titleName}
+              toggleHide={() => toggleHide(key)}
+              toggleStatusColor={toggleStatusColor}
+              openReport={openReport}
+            />
           );
         })}
       </section>

--- a/src/components/video/VideoParticipant.tsx
+++ b/src/components/video/VideoParticipant.tsx
@@ -1,0 +1,119 @@
+import { LocalParticipant, Participant } from 'livekit-client';
+import { MdReport, MdVisibility, MdVisibilityOff } from 'react-icons/md';
+import type { FocusStatus } from '../../store/focusStatusStore';
+import LiveVideoBox from './LiveVideoBox';
+
+interface Props {
+  participant: Participant;
+  identityKey: string;
+  idx: number;
+  displayName: string;
+  targetName: string;
+  isPlaceholder: boolean;
+  hidden: boolean;
+  focusStatus: FocusStatus;
+  titleIcon: string;
+  titleName: string;
+  toggleHide: () => void;
+  toggleStatusColor: (identity: string) => void;
+  openReport: (id: string, name: string) => void;
+}
+
+const VideoParticipant = ({
+  participant,
+  identityKey,
+  idx,
+  displayName,
+  targetName,
+  isPlaceholder,
+  hidden,
+  focusStatus,
+  titleIcon,
+  titleName,
+  toggleHide,
+  toggleStatusColor,
+  openReport,
+}: Props) => {
+  const dotColor =
+    focusStatus === 'focus'
+      ? 'bg-green-500'
+      : focusStatus === 'pause'
+      ? 'bg-red-500'
+      : 'bg-gray-400'; // idle
+
+  return (
+    <div
+      key={`${identityKey}-${idx}`}
+      className="bg-gray-100 rounded shadow-sm overflow-hidden flex items-center justify-center aspect-[4/3] relative"
+    >
+      <div className="w-full h-full bg-gray-200 rounded-md relative">
+        {/* 상태 점 */}
+        <div
+          onClick={() => {
+            if (isPlaceholder) return;
+            if (!(participant instanceof LocalParticipant) && !participant.isLocal) return;
+            toggleStatusColor(identityKey);
+          }}
+          className={`absolute top-1 left-1 w-2 h-2 rounded-full z-50 ${
+            isPlaceholder ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'
+          } ${dotColor}`}
+        />
+
+        {/* 타이머 */}
+        <div className="absolute top-1 right-1 flex justify-center items-center gap-[0.2rem] mt-[0.1rem]">
+          <span className="text-caption2_M text-white bg-black/50 px-1 rounded">01:59:59</span>
+        </div>
+
+        {/* 영상 */}
+        {hidden ? (
+          <div className="flex items-center justify-center w-full h-full bg-gray-300 text-sm text-gray-600 text-center px-2">
+            <p>
+              <span className="font-semibold text-black">{displayName}</span>님의 화면은 현재 가려졌습니다.
+            </p>
+          </div>
+        ) : (
+          <LiveVideoBox participant={participant} />
+        )}
+
+        {/* 하단 바 */}
+        <div className="absolute bottom-0 left-0 w-full px-2 py-1 bg-black/40 text-white text-xs flex items-center justify-center">
+          {/* 숨기기 버튼 */}
+          <button
+            disabled={isPlaceholder}
+            className={`absolute right-8 ${
+              isPlaceholder ? 'opacity-40 cursor-not-allowed' : 'text-gray-300 hover:text-gray-500'
+            }`}
+            onClick={() => !isPlaceholder && toggleHide()}
+          >
+            {hidden ? <MdVisibility size={16} /> : <MdVisibilityOff size={16} />}
+          </button>
+
+          {/* 칭호 + 닉네임 */}
+          <div className="flex items-center space-x-1">
+            <span className="text-sm">
+              {participant instanceof LocalParticipant || participant.isLocal ? titleIcon : '🌱'}
+            </span>
+            <span className="text-caption1_M text-lime-400 font-semibold">
+              {participant instanceof LocalParticipant || participant.isLocal ? titleName : '칭호'}
+            </span>
+            <span className="text-caption1_M font-semibold">{displayName}</span>
+          </div>
+
+          {/* 신고 버튼 */}
+          <button
+            disabled={isPlaceholder}
+            className={`absolute right-2 ${
+              isPlaceholder ? 'opacity-40 cursor-not-allowed' : 'text-red-300 hover:text-red-500'
+            }`}
+            onClick={() => !isPlaceholder && openReport(identityKey, targetName)}
+            aria-label="신고하기"
+          >
+            <MdReport size={16} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VideoParticipant;

--- a/src/components/video/VideoParticipant.tsx
+++ b/src/components/video/VideoParticipant.tsx
@@ -1,8 +1,9 @@
 import { LocalParticipant, Participant } from 'livekit-client';
 import { MdReport, MdVisibility, MdVisibilityOff } from 'react-icons/md';
+import { useTimer } from '../../hooks/useTimer';
 import type { FocusStatus } from '../../store/focusStatusStore';
+import { formatTime } from '../../utils/time';
 import LiveVideoBox from './LiveVideoBox';
-
 interface Props {
   participant: Participant;
   identityKey: string;
@@ -14,6 +15,9 @@ interface Props {
   focusStatus: FocusStatus;
   titleIcon: string;
   titleName: string;
+  totalStudyTime: number;
+  totalAwayTime: number;
+  statusChangedAt: string;
   toggleHide: () => void;
   toggleStatusColor: (identity: string) => void;
   openReport: (id: string, name: string) => void;
@@ -30,16 +34,30 @@ const VideoParticipant = ({
   focusStatus,
   titleIcon,
   titleName,
+  totalStudyTime,
+  totalAwayTime,
+  statusChangedAt,
   toggleHide,
   toggleStatusColor,
   openReport,
 }: Props) => {
+  const timerStatus: 'FOCUS' | 'AWAY' | 'IDLE' =
+    focusStatus === 'focus'
+      ? 'FOCUS'
+      : focusStatus === 'pause'
+      ? 'AWAY'
+      : 'IDLE';
+
+  const { studyTime } = useTimer(timerStatus, totalStudyTime, totalAwayTime, statusChangedAt);
+
   const dotColor =
     focusStatus === 'focus'
       ? 'bg-green-500'
       : focusStatus === 'pause'
+      ? 'bg-yellow-500'
+      : focusStatus === 'ended'
       ? 'bg-red-500'
-      : 'bg-gray-400'; // idle
+      : 'bg-gray-400';
 
   return (
     <div
@@ -61,7 +79,9 @@ const VideoParticipant = ({
 
         {/* 타이머 */}
         <div className="absolute top-1 right-1 flex justify-center items-center gap-[0.2rem] mt-[0.1rem]">
-          <span className="text-caption2_M text-white bg-black/50 px-1 rounded">01:59:59</span>
+          <span className="text-caption2_M text-white bg-black/50 px-1 rounded">
+            {formatTime(studyTime)}
+          </span>
         </div>
 
         {/* 영상 */}

--- a/src/components/video/VideoParticipant.tsx
+++ b/src/components/video/VideoParticipant.tsx
@@ -78,12 +78,14 @@ const VideoParticipant = ({
         />
 
         {/* 타이머 */}
-        <div className="absolute top-1 right-1 flex justify-center items-center gap-[0.2rem] mt-[0.1rem]">
-          <span className="text-caption2_M text-white bg-black/50 px-1 rounded">
+       <div className="absolute top-1 right-1 flex justify-center items-center gap-[0.2rem] mt-[0.1rem]">
+          <span
+            className="text-caption2_M text-white bg-black/50 px-1 rounded font-mono tabular-nums"
+          >
             {formatTime(studyTime)}
           </span>
         </div>
-
+        
         {/* 영상 */}
         {hidden ? (
           <div className="flex items-center justify-center w-full h-full bg-gray-300 text-sm text-gray-600 text-center px-2">

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useTimer(
+  status: 'FOCUS' | 'AWAY' | 'IDLE',
+  initialStudyTime: number,
+  initialAwayTime: number,
+  statusChangedAt: string
+) {
+  const [studyTime, setStudyTime] = useState(initialStudyTime);
+  const [awayTime, setAwayTime] = useState(initialAwayTime);
+
+  // 누적 기준값
+  const lastStudyRef = useRef(initialStudyTime);
+  const lastAwayRef = useRef(initialAwayTime);
+  const lastStatusRef = useRef<'FOCUS' | 'AWAY' | 'IDLE'>('IDLE');
+  const changedAtRef = useRef(new Date(statusChangedAt).getTime());
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | null = null;
+
+    // 상태가 바뀔 때마다 기준값 업데이트
+    if (lastStatusRef.current === 'FOCUS') {
+      lastStudyRef.current = studyTime;
+    } else if (lastStatusRef.current === 'AWAY') {
+      lastAwayRef.current = awayTime;
+    }
+    changedAtRef.current = Date.now();
+    lastStatusRef.current = status;
+
+    if (status === 'FOCUS' || status === 'AWAY') {
+      interval = setInterval(() => {
+        const now = Date.now();
+        const diff = Math.floor((now - changedAtRef.current) / 1000);
+
+        if (status === 'FOCUS') {
+          setStudyTime(lastStudyRef.current + diff);
+        } else if (status === 'AWAY') {
+          setAwayTime(lastAwayRef.current + diff);
+        }
+      }, 1000);
+    }
+
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [status]);
+
+  return { studyTime, awayTime };
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,7 @@
+// 초 단위 시간을 00:00:00 형태로 포맷팅
+export function formatTime(sec: number) {
+  const h = Math.floor(sec / 3600).toString().padStart(2, '0');
+  const m = Math.floor((sec % 3600) / 60).toString().padStart(2, '0');
+  const s = (sec % 60).toString().padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}


### PR DESCRIPTION
📌 작업 개요
VideoGrid의 복잡한 참가자 렌더링 로직을 VideoParticipant 컴포넌트로 분리
상태 점 색상/전환 로직 개선 (idle → focus → pause → focus)
참가자별 공부/이탈 시간을 추적할 수 있는 useTimer 훅 및 formatTime 유틸 추가

✅ 작업 내용
1 VideoGrid.tsx 내부의 참가자 UI/로직을 VideoParticipant.tsx로 분리

2. 상태 점 색상 & 상태 전환 로직 개선
기존: focus ↔ pause 단순 토글
변경: idle → focus → pause → focus 순환 가능
상태 점 색상: focus=green, pause=yellow, ended=red, idle=gray
API 연동: /api/timer/start, /api/timer/pause, /api/timer/resume

3. 타이머 훅 추가 (hooks/useTimer.ts)
FOCUS, AWAY, IDLE 상태별로 1초 단위 누적 관리
상태 전환 시 기준 시간을 저장해 resume 시 이어서 카운트 가능

4. 시간 포맷팅 유틸 추가 (utils/time.ts)
초 단위를 HH:MM:SS 형식으로 변환하는 formatTime 함수 추가